### PR TITLE
Fixes #15 - Adds unit tests to JavaScriptModuleBase

### DIFF
--- a/ReactWindows/ReactNative.Tests/Bridge/JavaScriptModuleBaseTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/JavaScriptModuleBaseTests.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using ReactNative.Bridge;
+using System;
+using System.Linq;
+
+namespace ReactNative.Tests.Bridge
+{
+    [TestClass]
+    public class JavaScriptModuleBaseTests
+    {
+        [TestMethod]
+        public void JavaScriptModuleBase_InvokeHandlerNotSet()
+        {
+            var module = new TestJavaScriptModule();
+            AssertEx.Throws<InvalidOperationException>(() => module.Foo());
+        }
+
+        [TestMethod]
+        public void JavaScriptModuleBase_InvokeHandler_SetMultiple()
+        {
+            var module = new TestJavaScriptModule();
+            module.InvocationHandler = new MockInvocationHandler();
+            AssertEx.Throws<InvalidOperationException>(() => module.InvocationHandler = new MockInvocationHandler());
+        }
+
+        [TestMethod]
+        public void JavaScriptModuleBase_Invoke()
+        {
+            var name = default(string);
+            var args = default(object[]);
+            var module = new TestJavaScriptModule();
+            module.InvocationHandler = new MockInvocationHandler((n, a) =>
+            {
+                name = n;
+                args = a;
+            });
+
+            module.Foo();
+            Assert.AreEqual(nameof(TestJavaScriptModule.Foo), name);
+            Assert.IsNull(args);
+
+            module.Foo1(1);
+            Assert.AreEqual(nameof(TestJavaScriptModule.Foo1), name);
+            Assert.IsTrue(args.SequenceEqual(new object[] { 1 }));
+
+            module.Foo2(1, 2);
+            Assert.AreEqual(nameof(TestJavaScriptModule.Foo2), name);
+            Assert.IsTrue(args.SequenceEqual(new object[] { 1, 2 }));
+
+            module.Foo3(1, 2, 3);
+            Assert.AreEqual(nameof(TestJavaScriptModule.Foo3), name);
+            Assert.IsTrue(args.SequenceEqual(new object[] { 1, 2, 3 }));
+
+            module.Foo4(1, 2, 3, 4);
+            Assert.AreEqual(nameof(TestJavaScriptModule.Foo4), name);
+            Assert.IsTrue(args.SequenceEqual(new object[] { 1, 2, 3, 4 }));
+
+            var expectedArgs = new object[] { null, "foo", 42 };
+            module.FooN(expectedArgs);
+            Assert.AreEqual(nameof(TestJavaScriptModule.FooN), name);
+            Assert.IsTrue(args.SequenceEqual(expectedArgs));
+        }
+
+        class TestJavaScriptModule : JavaScriptModuleBase
+        {
+            public void Foo()
+            {
+                Invoke();
+            }
+
+            public void Foo1(object p0)
+            {
+                Invoke(p0);
+            }
+
+            public void Foo2(object p0, object p1)
+            {
+                Invoke(p0, p1);
+            }
+
+            public void Foo3(object p0, object p1, object p2)
+            {
+                Invoke(p0, p1, p2);
+            }
+
+            public void Foo4(object p0, object p1, object p2, object p3)
+            {
+                Invoke(p0, p1, p2, p3);
+            }
+
+            public void FooN(object[] ps)
+            {
+                Invoke(ps);
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/Bridge/JavaScriptModuleRegistryTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/JavaScriptModuleRegistryTests.cs
@@ -80,17 +80,17 @@ namespace ReactNative.Tests.Bridge
         {
             public void Bar()
             {
-                Invoke(nameof(Bar));
+                Invoke();
             }
 
             public void Baz()
             {
-                Invoke(nameof(Baz));
+                Invoke();
             }
 
             public void Foo(int x)
             {
-                Invoke(nameof(Foo), x);
+                Invoke(x);
             }
         }
     }

--- a/ReactWindows/ReactNative.Tests/Internal/MockInvocationHandler.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/MockInvocationHandler.cs
@@ -1,0 +1,25 @@
+﻿using ReactNative.Bridge;
+using System;
+
+namespace ReactNative.Tests
+{
+    class MockInvocationHandler : IInvocationHandler
+    {
+        private readonly Action<string, object[]> _onInvoke;
+
+        public MockInvocationHandler()
+            : this((_, __) => { })
+        {
+        }
+
+        public MockInvocationHandler(Action<string, object[]> onInvoke)
+        {
+            _onInvoke = onInvoke;
+        }
+
+        public void Invoke(string name, object[] args)
+        {
+            _onInvoke(name, args);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/Modules/Core/RCTNativeAppEventEmitterTests.cs
+++ b/ReactWindows/ReactNative.Tests/Modules/Core/RCTNativeAppEventEmitterTests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using ReactNative.Modules.Core;
+
+namespace ReactNative.Tests.Modules.Core
+{
+    [TestClass]
+    public class RCTNativeAppEventEmitterTests
+    {
+        [TestMethod]
+        public void RCTEventEmitter_InvokeTests()
+        {
+            var module = new RCTNativeAppEventEmitter();
+
+            var name = default(string);
+            var args = default(object[]);
+            module.InvocationHandler = new MockInvocationHandler((n, a) =>
+            {
+                name = n;
+                args = a;
+            });
+
+            var eventName = "foo";
+            var data = new object();
+            module.emit(eventName, data);
+            Assert.AreEqual(nameof(RCTNativeAppEventEmitter.emit), name);
+            Assert.AreEqual(2, args.Length);
+            Assert.AreSame(eventName, args[0]);
+            Assert.AreSame(data, args[1]);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
+++ b/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
@@ -95,6 +95,7 @@
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Bridge\JavaScriptModuleBaseTests.cs" />
     <Compile Include="Bridge\JavaScriptModuleRegistryTests.cs" />
     <Compile Include="Bridge\JavaScriptModulesConfigTests.cs" />
     <Compile Include="Bridge\NativeModuleBaseTests.cs" />
@@ -106,7 +107,11 @@
     <Compile Include="Internal\JavaScriptHelpers.cs" />
     <Compile Include="Internal\DispatcherHelpers.cs" />
     <Compile Include="Internal\MockCatalystInstance.cs" />
+    <Compile Include="Internal\MockInvocationHandler.cs" />
+    <Compile Include="Modules\Core\RCTNativeAppEventEmitterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UIManager\AppRegistryTests.cs" />
+    <Compile Include="UIManager\Events\RCTEventEmitterTests.cs" />
     <Compile Include="UnitTestApp.xaml.cs">
       <DependentUpon>UnitTestApp.xaml</DependentUpon>
     </Compile>

--- a/ReactWindows/ReactNative.Tests/UIManager/AppRegistryTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/AppRegistryTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Newtonsoft.Json.Linq;
+using ReactNative.UIManager;
+
+namespace ReactNative.Tests.UIManager
+{
+    [TestClass]
+    public class AppRegistryTests
+    {
+        [TestMethod]
+        public void AppRegistry_InvokeTests()
+        {
+            var module = new AppRegistry();
+
+            var name = default(string);
+            var args = default(object[]);
+            module.InvocationHandler = new MockInvocationHandler((n, a) =>
+            {
+                name = n;
+                args = a;
+            });
+
+            var appKey = "foo";
+            var appParameters = new JObject();
+            module.runApplication(appKey, appParameters);
+            Assert.AreEqual(nameof(AppRegistry.runApplication), name);
+            Assert.AreEqual(2, args.Length);
+            Assert.AreSame(appKey, args[0]);
+            Assert.AreSame(appParameters, args[1]);
+
+            module.unmountApplicationComponentAtRootTag(42);
+            Assert.AreEqual(nameof(AppRegistry.unmountApplicationComponentAtRootTag), name);
+            Assert.AreEqual(1, args.Length);
+            Assert.AreEqual(42, args[0]);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/RCTEventEmitterTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/RCTEventEmitterTests.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Newtonsoft.Json.Linq;
+using ReactNative.Modules.Core;
+
+namespace ReactNative.Tests.UIManager.Events
+{
+    [TestClass]
+    public class RCTEventEmitterTests
+    {
+        [TestMethod]
+        public void RCTEventEmitter_InvokeTests()
+        {
+            var module = new RCTEventEmitter();
+
+            var name = default(string);
+            var args = default(object[]);
+            module.InvocationHandler = new MockInvocationHandler((n, a) =>
+            {
+                name = n;
+                args = a;
+            });
+
+            var targetTag = 42;
+            var eventName = "foo";
+            var @event = new JObject();
+            module.receiveEvent(targetTag, eventName, @event);
+            Assert.AreEqual(nameof(RCTEventEmitter.receiveEvent), name);
+            Assert.AreEqual(3, args.Length);
+            Assert.AreEqual(targetTag, args[0]);
+            Assert.AreSame(eventName, args[1]);
+            Assert.AreSame(@event, args[2]);
+
+            var touches = new JArray();
+            var changedIndices = new JArray();
+            module.receiveTouches(eventName, touches, changedIndices);
+            Assert.AreEqual(nameof(RCTEventEmitter.receiveTouches), name);
+            Assert.AreEqual(3, args.Length);
+            Assert.AreSame(eventName, args[0]);
+            Assert.AreSame(touches, args[1]);
+            Assert.AreSame(changedIndices, args[2]);
+        }
+    }
+}

--- a/ReactWindows/ReactNative/Bridge/JavaScriptModuleBase.Generated.cs
+++ b/ReactWindows/ReactNative/Bridge/JavaScriptModuleBase.Generated.cs
@@ -1,0 +1,121 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// Base class for <see cref="IJavaScriptModule"/>s.
+    /// </summary>
+    public abstract partial class JavaScriptModuleBase : IJavaScriptModule
+    {
+		/// <summary>
+        /// Invoke a JavaScript method with the given arguments.
+        /// </summary>
+        /// <param name="caller">
+        /// The name of the method. This parameter may be ignored if the name
+        /// of the native method matches the name of the JavaScript method. The
+        /// method name will be filled in automatically using the
+        /// <see cref="CallerMemberNameAttribute"/>.
+        /// </param>
+        /// <remarks>
+        /// The expectation is that <see cref="IJavaScriptModule"/>s will use
+        /// this method to notify the framework of a JavaScript call to be
+        /// executed. This is to overcome the absense of a performant "proxy"
+        /// implementation in the .NET framework.
+        /// </remarks>
+		protected void Invoke([CallerMemberName]string caller = null)
+		{
+			Invoke(default(object[]), caller);
+		}
+
+		/// <summary>
+        /// Invoke a JavaScript method with the given arguments.
+        /// </summary>
+        /// <param name="arg0">The first argument.</param>
+        /// <param name="caller">
+        /// The name of the method. This parameter may be ignored if the name
+        /// of the native method matches the name of the JavaScript method. The
+        /// method name will be filled in automatically using the
+        /// <see cref="CallerMemberNameAttribute"/>.
+        /// </param>
+        /// <remarks>
+        /// The expectation is that <see cref="IJavaScriptModule"/>s will use
+        /// this method to notify the framework of a JavaScript call to be
+        /// executed. This is to overcome the absense of a performant "proxy"
+        /// implementation in the .NET framework.
+        /// </remarks>
+		protected void Invoke(object arg0, [CallerMemberName]string caller = null)
+		{
+			Invoke(new[] { arg0 }, caller);
+		}
+
+		/// <summary>
+        /// Invoke a JavaScript method with the given arguments.
+        /// </summary>
+        /// <param name="arg0">The first argument.</param>
+        /// <param name="arg1">The second argument.</param>
+        /// <param name="caller">
+        /// The name of the method. This parameter may be ignored if the name
+        /// of the native method matches the name of the JavaScript method. The
+        /// method name will be filled in automatically using the
+        /// <see cref="CallerMemberNameAttribute"/>.
+        /// </param>
+        /// <remarks>
+        /// The expectation is that <see cref="IJavaScriptModule"/>s will use
+        /// this method to notify the framework of a JavaScript call to be
+        /// executed. This is to overcome the absense of a performant "proxy"
+        /// implementation in the .NET framework.
+        /// </remarks>
+		protected void Invoke(object arg0, object arg1, [CallerMemberName]string caller = null)
+		{
+			Invoke(new[] { arg0, arg1 }, caller);
+		}
+
+		/// <summary>
+        /// Invoke a JavaScript method with the given arguments.
+        /// </summary>
+        /// <param name="arg0">The first argument.</param>
+        /// <param name="arg1">The second argument.</param>
+        /// <param name="arg2">The third argument.</param>
+        /// <param name="caller">
+        /// The name of the method. This parameter may be ignored if the name
+        /// of the native method matches the name of the JavaScript method. The
+        /// method name will be filled in automatically using the
+        /// <see cref="CallerMemberNameAttribute"/>.
+        /// </param>
+        /// <remarks>
+        /// The expectation is that <see cref="IJavaScriptModule"/>s will use
+        /// this method to notify the framework of a JavaScript call to be
+        /// executed. This is to overcome the absense of a performant "proxy"
+        /// implementation in the .NET framework.
+        /// </remarks>
+		protected void Invoke(object arg0, object arg1, object arg2, [CallerMemberName]string caller = null)
+		{
+			Invoke(new[] { arg0, arg1, arg2 }, caller);
+		}
+
+		/// <summary>
+        /// Invoke a JavaScript method with the given arguments.
+        /// </summary>
+        /// <param name="arg0">The first argument.</param>
+        /// <param name="arg1">The second argument.</param>
+        /// <param name="arg2">The third argument.</param>
+        /// <param name="arg3">The fourth argument.</param>
+        /// <param name="caller">
+        /// The name of the method. This parameter may be ignored if the name
+        /// of the native method matches the name of the JavaScript method. The
+        /// method name will be filled in automatically using the
+        /// <see cref="CallerMemberNameAttribute"/>.
+        /// </param>
+        /// <remarks>
+        /// The expectation is that <see cref="IJavaScriptModule"/>s will use
+        /// this method to notify the framework of a JavaScript call to be
+        /// executed. This is to overcome the absense of a performant "proxy"
+        /// implementation in the .NET framework.
+        /// </remarks>
+		protected void Invoke(object arg0, object arg1, object arg2, object arg3, [CallerMemberName]string caller = null)
+		{
+			Invoke(new[] { arg0, arg1, arg2, arg3 }, caller);
+		}
+
+    }
+}

--- a/ReactWindows/ReactNative/Bridge/JavaScriptModuleBase.Generated.tt
+++ b/ReactWindows/ReactNative/Bridge/JavaScriptModuleBase.Generated.tt
@@ -1,0 +1,80 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+var maxArgs = 4;
+var ordinals = new[]
+{
+	"first",
+	"second",
+	"third",
+	"fourth",
+	"fifth",
+	"sixth",
+	"seventh",
+};
+#>
+using System.Runtime.CompilerServices;
+
+namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// Base class for <see cref="IJavaScriptModule"/>s.
+    /// </summary>
+    public abstract partial class JavaScriptModuleBase : IJavaScriptModule
+    {
+<#
+for (var i = 0; i <= maxArgs; ++i)
+{
+    var paramNames = Enumerable.Range(0, i).Select(x => "arg" + x).ToList();
+	var paramArgs = paramNames.Select(x => "object " + x).ToList();
+#>
+		/// <summary>
+        /// Invoke a JavaScript method with the given arguments.
+        /// </summary>
+<#
+    for (var j = 0; j < i; ++j)
+	{
+#>
+        /// <param name="<#=paramNames[j]#>">The <#=ordinals[j]#> argument.</param>
+<#
+    }
+#>
+        /// <param name="caller">
+        /// The name of the method. This parameter may be ignored if the name
+        /// of the native method matches the name of the JavaScript method. The
+        /// method name will be filled in automatically using the
+        /// <see cref="CallerMemberNameAttribute"/>.
+        /// </param>
+        /// <remarks>
+        /// The expectation is that <see cref="IJavaScriptModule"/>s will use
+        /// this method to notify the framework of a JavaScript call to be
+        /// executed. This is to overcome the absense of a performant "proxy"
+        /// implementation in the .NET framework.
+        /// </remarks>
+		protected void Invoke(<#=string.Join("", paramArgs.Select(x => x + ", "))#>[CallerMemberName]string caller = null)
+		{
+<#
+    if (i == 0)
+	{
+#>
+			Invoke(default(object[]), caller);
+<#
+    }
+	else
+	{
+#>
+			Invoke(new[] { <#=string.Join(", ", paramNames)#> }, caller);
+<#
+    }
+#>
+		}
+
+<#
+}
+#>
+    }
+}

--- a/ReactWindows/ReactNative/Bridge/JavaScriptModuleBase.cs
+++ b/ReactWindows/ReactNative/Bridge/JavaScriptModuleBase.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace ReactNative.Bridge
 {
     /// <summary>
     /// Base class for <see cref="IJavaScriptModule"/>s.
     /// </summary>
-    public abstract class JavaScriptModuleBase : IJavaScriptModule
+    public abstract partial class JavaScriptModuleBase : IJavaScriptModule
     {
         private IInvocationHandler _invokeHandler;
 
@@ -26,24 +27,32 @@ namespace ReactNative.Bridge
         }
 
         /// <summary>
-        /// Invoke a method by name.
+        /// Invoke a JavaScript method with the given arguments.
         /// </summary>
-        /// <param name="name">The name of the method.</param>
         /// <param name="args">The arguments.</param>
+        /// <param name="caller">
+        /// The name of the method. This parameter may be ignored if the name
+        /// of the native method matches the name of the JavaScript method. The
+        /// method name will be filled in automatically using the
+        /// <see cref="CallerMemberNameAttribute"/>.
+        /// </param>
         /// <remarks>
         /// The expectation is that <see cref="IJavaScriptModule"/>s will use
         /// this method to notify the framework of a JavaScript call to be
         /// executed. This is to overcome the absense of a performant "proxy"
         /// implementation in the .NET framework.
         /// </remarks>
-        protected void Invoke(string name, params object[] args)
+        protected void Invoke(object[] args, [CallerMemberName]string caller = null)
         {
+            if (caller == null)
+                throw new ArgumentNullException(nameof(caller));
+
             if (_invokeHandler == null)
             {
                 throw new InvalidOperationException("InvokeHandler has not been set.");
             }
 
-            _invokeHandler.Invoke(name, args);
+            _invokeHandler.Invoke(caller, args);
         }
     }
 }

--- a/ReactWindows/ReactNative/Modules/Core/RCTNativeAppEventEmitter.cs
+++ b/ReactWindows/ReactNative/Modules/Core/RCTNativeAppEventEmitter.cs
@@ -14,7 +14,7 @@ namespace ReactNative.Modules.Core
         /// <param name="data">The event data.</param>
         public void emit(string eventName, object data)
         {
-            Invoke(nameof(emit), eventName, data);
+            Invoke(eventName, data);
         }
     }
 }

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -117,6 +117,11 @@
     <Compile Include="Bridge\IReactCallback.cs" />
     <Compile Include="Bridge\IReactDelegateFactory.cs" />
     <Compile Include="Bridge\JavaScriptModuleBase.cs" />
+    <Compile Include="Bridge\JavaScriptModuleBase.Generated.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>JavaScriptModuleBase.Generated.tt</DependentUpon>
+    </Compile>
     <Compile Include="Bridge\JavaScriptModuleRegistration.cs" />
     <Compile Include="Bridge\JavaScriptModuleRegistry.cs" />
     <Compile Include="Bridge\JavaScriptModulesConfig.cs" />
@@ -182,7 +187,15 @@
     <Compile Include="UIManager\AppRegistry.cs" />
     <EmbeddedResource Include="Properties\ReactNative.rd.xml" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="Bridge\JavaScriptModuleBase.Generated.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>JavaScriptModuleBase.Generated.cs</LastGenOutput>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/ReactWindows/ReactNative/UIManager/AppRegistry.cs
+++ b/ReactWindows/ReactNative/UIManager/AppRegistry.cs
@@ -13,18 +13,18 @@ namespace ReactNative.UIManager
         /// </summary>
         /// <param name="appKey">The app key.</param>
         /// <param name="appParameters">The app parameters.</param>
-        void runApplication(string appKey, JObject appParameters)
+        public void runApplication(string appKey, JObject appParameters)
         {
-            Invoke(nameof(runApplication), appKey, appParameters);
+            Invoke(appKey, appParameters);
         }
 
         /// <summary>
         /// Unmount the application.
         /// </summary>
         /// <param name="rootTagNode">The root tag node.</param>
-        void unmountApplicationComponentAtRootTag(int rootTagNode)
+        public void unmountApplicationComponentAtRootTag(int rootTagNode)
         {
-            Invoke(nameof(unmountApplicationComponentAtRootTag), rootTagNode);
+            Invoke(rootTagNode);
         }
     }
 }

--- a/ReactWindows/ReactNative/UIManager/Events/RCTEventEmitter.cs
+++ b/ReactWindows/ReactNative/UIManager/Events/RCTEventEmitter.cs
@@ -16,7 +16,7 @@ namespace ReactNative.Modules.Core
         /// <param name="event">The event data.</param>
         public void receiveEvent(int targetTag, string eventName, JObject @event)
         {
-            Invoke(nameof(receiveEvent), targetTag, eventName, @event);
+            Invoke(targetTag, eventName, @event);
         }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace ReactNative.Modules.Core
         /// <param name="changedIndices">The changed indices.</param>
         public void receiveTouches(string eventName, JArray touches, JArray changedIndices)
         {
-            Invoke(nameof(receiveTouches), touches, changedIndices);
+            Invoke(eventName, touches, changedIndices);
         }
     }
 }


### PR DESCRIPTION
Additionally, includes unit tests for the current set of core JavaScript modules.

Also refactors the way that implementations of JavaScript modules trigger the invocation, using the CallerMemberNameAttribute to capture the name of the method, rather than passing it in explicitly.