### PR TITLE
Fixes #62 - Adds EventDispatcher

### DIFF
--- a/ReactWindows/ReactNative.Tests/Bridge/ReactContextNativeModuleBaseTests.cs
+++ b/ReactWindows/ReactNative.Tests/Bridge/ReactContextNativeModuleBaseTests.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using ReactNative.Bridge;
+using System;
+
+namespace ReactNative.Tests.Bridge
+{
+    [TestClass]
+    public class ReactContextNativeModuleBaseTests
+    {
+        [TestMethod]
+        public void ReactContextNativeModuleBase_ArgumentChecks()
+        {
+            AssertEx.Throws<ArgumentNullException>(
+                () => new TestModule(null),
+                ex => Assert.AreEqual("reactContext", ex.ParamName));
+
+            var context = new ReactApplicationContext();
+            var module = new TestModule(context);
+            Assert.AreSame(context, module.Context);
+        }
+
+        class TestModule : ReactContextNativeModuleBase
+        {
+            public TestModule(ReactApplicationContext reactContext)
+                : base(reactContext)
+            {
+            }
+
+            public override string Name
+            {
+                get
+                {
+                    return "Test";
+                }
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/Internal/Constants/DictionaryHelpers.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/Constants/DictionaryHelpers.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+
+namespace ReactNative.Tests.Constants
+{
+    static class DictionaryHelpers
+    {
+        public static TValue Get<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            var result = default(TValue);
+            if (dictionary.TryGetValue(key, out result))
+            {
+                return result;
+            }
+
+            return default(TValue);
+        }
+
+        public static IReadOnlyDictionary<string, object> AsMap(this object value)
+        {
+            return value as IReadOnlyDictionary<string, object>;
+        }
+
+        public static object GetValue(this object value, string key)
+        {
+            var map = value.AsMap();
+            if (map == null)
+            {
+                return null;
+            }
+
+            return map.Get(key);
+        }
+
+        public static IReadOnlyDictionary<string, object> GetMap(this object value, string key)
+        {
+            return GetValue(value, key).AsMap();
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/Internal/JavaScriptHelpers.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/JavaScriptHelpers.cs
@@ -62,6 +62,8 @@ namespace ReactNative.Tests
 
             await jsQueueThread.CallOnQueue(() =>
             {
+                executor.Initialize();
+
                 foreach (var script in scripts)
                 {
                     executor.RunScript(script);

--- a/ReactWindows/ReactNative.Tests/Internal/MockEvent.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/MockEvent.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json.Linq;
+using ReactNative.UIManager.Events;
+using System;
+
+namespace ReactNative.Tests
+{
+    class MockEvent : Event
+    {
+        private readonly string _eventName;
+        private readonly JObject _eventArgs;
+
+        public MockEvent(int viewTag, TimeSpan timestamp, string eventName, JObject eventArgs)
+            : base(viewTag, timestamp)
+        {
+            _eventName = eventName;
+            _eventArgs = eventArgs;
+        }
+
+        public override string EventName
+        {
+            get
+            {
+                return _eventName;
+            }
+        }
+
+        public override void Dispatch(RCTEventEmitter eventEmitter)
+        {
+            eventEmitter.receiveEvent(ViewTag, EventName, _eventArgs);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/Internal/MockJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/MockJavaScriptExecutor.cs
@@ -7,24 +7,29 @@ namespace ReactNative.Tests
     class MockJavaScriptExecutor : IJavaScriptExecutor
     {
         private readonly Func<string, string, JArray, JToken> _onCall;
+        private readonly Action<string> _runScript;
         private readonly Action<string, JToken> _onSetGlobalVariable;
         private readonly Action _onDispose;
 
         public MockJavaScriptExecutor(
             Func<string, string, JArray, JToken> onCall)
-            : this(onCall, (_, __) => { }, () => { })
+            : this(onCall, _ => { }, (_, __) => { }, () => { })
         {
         }
 
         public MockJavaScriptExecutor(
             Func<string, string, JArray, JToken> onCall,
+            Action<string> runScript,
             Action<string, JToken> onSetGlobalVariable,
             Action onDispose)
         {
             _onCall = onCall;
+            _runScript = runScript;
             _onSetGlobalVariable = onSetGlobalVariable;
             _onDispose = onDispose;
         }
+
+        public void Initialize() { }
 
         public JToken Call(string moduleName, string methodName, JArray arguments)
         {
@@ -33,7 +38,7 @@ namespace ReactNative.Tests
 
         public void RunScript(string script)
         {
-            throw new NotImplementedException();
+            _runScript(script);
         }
 
         public void SetGlobalVariable(string propertyName, JToken value)

--- a/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
+++ b/ReactWindows/ReactNative.Tests/ReactNative.Tests.csproj
@@ -101,21 +101,27 @@
     <Compile Include="Bridge\JavaScriptModulesConfigTests.cs" />
     <Compile Include="Bridge\NativeModuleBaseTests.cs" />
     <Compile Include="Bridge\Queue\MessageQueueThreadTests.cs" />
+    <Compile Include="Bridge\ReactContextNativeModuleBaseTests.cs" />
     <Compile Include="Hosting\Bridge\ChakraJavaScriptExecutorTests.cs" />
     <Compile Include="Hosting\Bridge\ReactBridgeTests.cs" />
     <Compile Include="Internal\AssertEx.cs" />
     <Compile Include="Bridge\NativeModuleRegistryTests.cs" />
+    <Compile Include="Internal\Constants\DictionaryHelpers.cs" />
     <Compile Include="Internal\JavaScriptHelpers.cs" />
     <Compile Include="Internal\DispatcherHelpers.cs" />
     <Compile Include="Internal\MockCatalystInstance.cs" />
     <Compile Include="Internal\MockInvocationHandler.cs" />
     <Compile Include="Internal\MockJavaScriptExecutor.cs" />
+    <Compile Include="Internal\MockEvent.cs" />
     <Compile Include="Modules\Core\RCTDeviceEventEmitterTests.cs" />
     <Compile Include="Modules\Core\RCTNativeAppEventEmitterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReactInstanceManagerTests.cs" />
     <Compile Include="UIManager\AppRegistryTests.cs" />
+    <Compile Include="UIManager\Events\EventDispatcherTests.cs" />
+    <Compile Include="UIManager\Events\EventTests.cs" />
     <Compile Include="UIManager\Events\RCTEventEmitterTests.cs" />
+    <Compile Include="UIManager\UIManagerModuleTests.cs" />
     <Compile Include="UnitTestApp.xaml.cs">
       <DependentUpon>UnitTestApp.xaml</DependentUpon>
     </Compile>
@@ -157,6 +163,7 @@
       <Name>ReactNative</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
@@ -1,0 +1,160 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Newtonsoft.Json.Linq;
+using ReactNative.Bridge;
+using ReactNative.Bridge.Queue;
+using ReactNative.UIManager.Events;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ReactNative.Tests.UIManager.Events
+{
+    [TestClass]
+    public class EventDispatcherTests
+    {
+        [TestMethod]
+        public void EventDispatcher_ArgumentChecks()
+        {
+            AssertEx.Throws<ArgumentNullException>(() => new EventDispatcher(null), ex => Assert.AreEqual("reactContext", ex.ParamName));
+
+            var context = new ReactApplicationContext();
+            var dispatcher = new EventDispatcher(context);
+            AssertEx.Throws<ArgumentNullException>(() => dispatcher.DispatchEvent(null), ex => Assert.AreEqual("event", ex.ParamName));
+        }
+
+        [TestMethod]
+        public void EventDispatcher_IncorrectThreadCalls()
+        {
+            var context = new ReactApplicationContext();
+            var dispatcher = new EventDispatcher(context);
+
+            AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnResume());
+            AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnSuspend());
+            AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnSuspend());
+            AssertEx.Throws<InvalidOperationException>(() => dispatcher.OnCatalystInstanceDispose());
+        }
+
+        [TestMethod]
+        public async Task EventDispatcher_EventDispatches()
+        {
+            var eventHandler = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                eventHandler.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo", new JObject());
+            dispatcher.DispatchEvent(testEvent);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnBatchComplete);
+
+            Assert.IsTrue(eventHandler.WaitOne());
+        }
+
+        [TestMethod]
+        public async Task EventDispatcher_OnSuspend_EventDoesNotDispatch()
+        {
+            var eventHandler = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                eventHandler.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo", new JObject());
+            dispatcher.DispatchEvent(testEvent);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnSuspend);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnBatchComplete);
+
+            Assert.IsFalse(eventHandler.WaitOne(500));
+        }
+
+        [TestMethod]
+        public async Task EventDispatcher_OnShutdown_EventDoesNotDispatch()
+        {
+            var eventHandler = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                eventHandler.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo", new JObject());
+            dispatcher.DispatchEvent(testEvent);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnShutdown);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnBatchComplete);
+
+            Assert.IsFalse(eventHandler.WaitOne(500));
+        }
+
+        [TestMethod]
+        public async Task EventDispatcher_OnCatalystInstanceDispose_EventDoesNotDispatch()
+        {
+            var eventHandler = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                eventHandler.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo", new JObject());
+            dispatcher.DispatchEvent(testEvent);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnCatalystInstanceDispose);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnBatchComplete);
+
+            Assert.IsFalse(eventHandler.WaitOne(500));
+        }
+
+        private static async Task<ReactApplicationContext> CreateContextAsync(IJavaScriptExecutor executor)
+        {
+            var catalystInstance = await DispatcherHelpers.CallOnDispatcherAsync(() => CreateCatalystInstance(executor));
+            await InitializeCatalystInstanceAsync(catalystInstance);
+            var context = new ReactApplicationContext();
+            context.InitializeWithInstance(catalystInstance);
+            return context;
+        }
+
+        private static CatalystInstance CreateCatalystInstance(IJavaScriptExecutor executor)
+        {
+            var registry = new NativeModuleRegistry.Builder().Build();
+            var jsModules = new JavaScriptModulesConfig.Builder()
+                .Add<RCTEventEmitter>()
+                .Build();
+
+            var instance = new CatalystInstance.Builder
+            {
+                QueueConfigurationSpec = CatalystQueueConfigurationSpec.Default,
+                BundleLoader = JavaScriptBundleLoader.CreateFileLoader("ms-appx:///Resources/test.js"),
+                JavaScriptModulesConfig = jsModules,
+                Registry = registry,
+                JavaScriptExecutor = executor,
+                NativeModuleCallExceptionHandler = ex => Assert.Fail(ex.ToString()),
+            }.Build();
+
+            instance.Initialize();
+
+            return instance;
+        }
+
+        private static Task InitializeCatalystInstanceAsync(CatalystInstance catalystInstance)
+        {
+            return catalystInstance.InitializeBridgeAsync();
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/EventTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/EventTests.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace ReactNative.Tests.UIManager.Events
+{
+    [TestClass]
+    public class EventTests
+    {
+        [TestMethod]
+        public void Event_Initialize_Dispose()
+        {
+            var e = new MockEvent(42, TimeSpan.FromSeconds(10), "Test", new JObject());
+
+            Assert.IsTrue(e.IsInitialized);
+
+            Assert.AreEqual(42, e.ViewTag);
+            Assert.AreEqual(TimeSpan.FromSeconds(10), e.Timestamp);
+            Assert.AreEqual(0, e.CoalescingKey);
+            Assert.IsTrue(e.CanCoalesce);
+
+            e.Dispose();
+            Assert.IsFalse(e.IsInitialized);
+        }
+    }
+}

--- a/ReactWindows/ReactNative.Tests/UIManager/UIManagerModuleTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/UIManagerModuleTests.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using ReactNative.Bridge;
+using ReactNative.Tests.Constants;
+using ReactNative.UIManager;
+using System;
+using System.Collections.Generic;
+
+namespace ReactNative.Tests.UIManager
+{
+    [TestClass]
+    public class UIManagerModuleTests
+    {
+        [TestMethod]
+        public void UIManagerModule_ArgumentChecks()
+        {
+            var context = new ReactApplicationContext();
+            var viewManagers = new List<IViewManager>();
+            var uiImplementation = new UIImplementation(context, viewManagers);
+
+            AssertEx.Throws<ArgumentNullException>(
+                () => new UIManagerModule(context, null, uiImplementation),
+                ex => Assert.AreEqual("viewManagers", ex.ParamName));
+
+            AssertEx.Throws<ArgumentNullException>(
+                () => new UIManagerModule(context, viewManagers, null),
+                ex => Assert.AreEqual("uiImplementation", ex.ParamName));
+        }
+
+        [TestMethod]
+        public void UIManagerModule_CustomEvents_Constants()
+        {
+            var context = new ReactApplicationContext();
+            var viewManagers = new List<IViewManager>();
+            var uiImplementation = new UIImplementation(context, viewManagers);
+
+            var module = new UIManagerModule(context, viewManagers, uiImplementation);
+            var constants = module.Constants;
+
+            Assert.AreEqual("onSelect", constants.GetMap("customBubblingEventTypes").GetMap("topSelect").GetMap("phasedRegistrationNames").GetValue("bubbled"));
+            Assert.AreEqual("onSelectCapture", constants.GetMap("customBubblingEventTypes").GetMap("topSelect").GetMap("phasedRegistrationNames").GetValue("captured"));
+            Assert.AreEqual("onChange", constants.GetMap("customBubblingEventTypes").GetMap("topChange").GetMap("phasedRegistrationNames").GetValue("bubbled"));
+            Assert.AreEqual("onChangeCapture", constants.GetMap("customBubblingEventTypes").GetMap("topChange").GetMap("phasedRegistrationNames").GetValue("captured"));
+            Assert.AreEqual("onTouchStart", constants.GetMap("customBubblingEventTypes").GetMap("topTouchStart").GetMap("phasedRegistrationNames").GetValue("bubbled"));
+            Assert.AreEqual("onTouchStartCapture", constants.GetMap("customBubblingEventTypes").GetMap("topTouchStart").GetMap("phasedRegistrationNames").GetValue("captured"));
+            Assert.AreEqual("onTouchMove", constants.GetMap("customBubblingEventTypes").GetMap("topTouchMove").GetMap("phasedRegistrationNames").GetValue("bubbled"));
+            Assert.AreEqual("onTouchMoveCapture", constants.GetMap("customBubblingEventTypes").GetMap("topTouchMove").GetMap("phasedRegistrationNames").GetValue("captured"));
+            Assert.AreEqual("onTouchEnd", constants.GetMap("customBubblingEventTypes").GetMap("topTouchEnd").GetMap("phasedRegistrationNames").GetValue("bubbled"));
+            Assert.AreEqual("onTouchEndCapture", constants.GetMap("customBubblingEventTypes").GetMap("topTouchEnd").GetMap("phasedRegistrationNames").GetValue("captured"));
+
+            Assert.AreEqual("onSelectionChange", constants.GetMap("customDirectEventTypes").GetMap("topSelectionChange").GetValue("registrationName"));
+            Assert.AreEqual("onLoadingStart", constants.GetMap("customDirectEventTypes").GetMap("topLoadingStart").GetValue("registrationName"));
+            Assert.AreEqual("onLoadingFinish", constants.GetMap("customDirectEventTypes").GetMap("topLoadingFinish").GetValue("registrationName"));
+            Assert.AreEqual("onLoadingError", constants.GetMap("customDirectEventTypes").GetMap("topLoadingError").GetValue("registrationName"));
+            Assert.AreEqual("onLayout", constants.GetMap("customDirectEventTypes").GetMap("topLayout").GetValue("registrationName"));
+        }
+
+        [TestMethod]
+        public void UIManagerModule_Constants_ViewManagerOverrides()
+        {
+            var context = new ReactApplicationContext();
+            var viewManagers = new List<IViewManager> { new TestViewManager() };
+            var uiImplementation = new UIImplementation(context, viewManagers);
+
+            var module = new UIManagerModule(context, viewManagers, uiImplementation);
+            var constants = module.Constants;
+
+            Assert.AreEqual(42, constants.GetMap("customDirectEventTypes").GetValue("otherSelectionChange"));
+            Assert.AreEqual(42, constants.GetMap("customDirectEventTypes").GetMap("topSelectionChange").GetValue("registrationName"));
+            Assert.AreEqual(42, constants.GetMap("customDirectEventTypes").GetMap("topLoadingStart").GetValue("foo"));
+            Assert.AreEqual(42, constants.GetMap("customDirectEventTypes").GetValue("topLoadingError"));
+        }
+
+        class TestViewManager : IViewManager
+        {
+            public IReadOnlyDictionary<string, object> CommandsMap
+            {
+                get
+                {
+                    return null;
+                }
+            }
+
+            public IReadOnlyDictionary<string, object> ExportedCustomBubblingEventTypeConstants
+            {
+                get
+                {
+                    return null;
+                }
+            }
+
+            public IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants
+            {
+                get
+                {
+                    return new Dictionary<string, object>
+                    {
+                        { "otherSelectionChange", 42 },
+                        { "topSelectionChange", new Dictionary<string, object> { { "registrationName", 42 } } },
+                        { "topLoadingStart", new Dictionary<string, object> { { "foo", 42 } } },
+                        { "topLoadingError", 42 },
+                    };
+                }
+            }
+
+            public IReadOnlyDictionary<string, object> ExportedViewConstants
+            {
+                get
+                {
+                    return null;
+                }
+            }
+
+            public string Name
+            {
+                get
+                {
+                    return "Test";
+                }
+            }
+
+            public IReadOnlyDictionary<string, string> NativeProperties
+            {
+                get
+                {
+                    return null;
+                }
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative/Bridge/CatalystInstance.cs
+++ b/ReactWindows/ReactNative/Bridge/CatalystInstance.cs
@@ -159,6 +159,7 @@ namespace ReactNative.Bridge
             {
                 QueueConfiguration.JSQueueThread.AssertIsOnThread();
 
+                _jsExecutor.Initialize();
                 _bundleLoader.LoadScript(_jsExecutor);
 
                 using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "ReactBridgeCtor"))

--- a/ReactWindows/ReactNative/Bridge/IJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Bridge/IJavaScriptExecutor.cs
@@ -9,6 +9,14 @@ namespace ReactNative.Bridge
     public interface IJavaScriptExecutor : IDisposable
     {
         /// <summary>
+        /// Initializes the JavaScript runtime.
+        /// </summary>
+        /// <remarks>
+        /// Must be called from the JavaScript thread.
+        /// </remarks>
+        void Initialize();
+
+        /// <summary>
         /// Call the JavaScript method from the given module.
         /// </summary>
         /// <param name="moduleName">The module name.</param>

--- a/ReactWindows/ReactNative/Bridge/NativeModuleBase.cs
+++ b/ReactWindows/ReactNative/Bridge/NativeModuleBase.cs
@@ -132,18 +132,6 @@ namespace ReactNative.Bridge
         {
         }
 
-        /// <summary>
-        /// Create the set of constants to configure the global environment.
-        /// </summary>
-        /// <returns>The set of constants.</returns>
-        /// <remarks>
-        /// This virtual method will be called during <see cref="Initialize"/>.
-        /// </remarks>
-        protected virtual IReadOnlyDictionary<string, object> CreateConstants()
-        {
-            return new Dictionary<string, object>();
-        }
-
         private IReadOnlyDictionary<string, INativeMethod> InitializeMethods()
         {
             var declaredMethods = GetType().GetTypeInfo().DeclaredMethods;

--- a/ReactWindows/ReactNative/Bridge/Queue/MessageQueueThread.cs
+++ b/ReactWindows/ReactNative/Bridge/Queue/MessageQueueThread.cs
@@ -148,26 +148,19 @@ namespace ReactNative.Bridge.Queue
             {
                 _name = name;
                 _actionObservable = new Subject<Action>();
-                try
-                {
-                    _subscription = _actionObservable
-                                    .ObserveOnDispatcher()
-                                    .Subscribe(action =>
-                                    {
-                                        try
-                                        {
-                                            action();
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            handler(ex);
-                                        }
-                                    });
-                                    }
-                catch (Exception ex)
-                {
-                    handler(ex);
-                }
+                _subscription = _actionObservable
+                    .ObserveOnDispatcher()
+                    .Subscribe(action =>
+                    {
+                        try
+                        {
+                            action();
+                        }
+                        catch (Exception ex)
+                        {
+                            handler(ex);
+                        }
+                    });
             }
 
             protected override void Enqueue(Action action)

--- a/ReactWindows/ReactNative/Bridge/ReactContext.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactContext.cs
@@ -11,7 +11,7 @@ namespace ReactNative.Bridge
     /// </summary>
     public abstract class ReactContext
     {
-        private readonly ReaderWriterLockSlim _lock;
+        private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
         private readonly List<ILifecycleEventListener> _lifecycleEventListeners =
             new List<ILifecycleEventListener>();
 

--- a/ReactWindows/ReactNative/Bridge/ReactContextNativeModuleBase.cs
+++ b/ReactWindows/ReactNative/Bridge/ReactContextNativeModuleBase.cs
@@ -1,4 +1,6 @@
-﻿namespace ReactNative.Bridge
+﻿using System;
+
+namespace ReactNative.Bridge
 {
     /// <summary>
     /// Base class for catalyst native modules that require access to the 
@@ -9,10 +11,13 @@
         /// <summary>
         /// Instantiates the <see cref="ReactContextNativeModuleBase"/>.
         /// </summary>
-        /// <param name="context">The context.</param>
-        protected ReactContextNativeModuleBase(ReactContext context)
+        /// <param name="reactContext">The React context.</param>
+        protected ReactContextNativeModuleBase(ReactContext reactContext)
         {
-            Context = context;
+            if (reactContext == null)
+                throw new ArgumentNullException(nameof(reactContext));
+
+            Context = reactContext;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Hosting/Bridge/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Hosting/Bridge/ChakraJavaScriptExecutor.cs
@@ -10,16 +10,24 @@ namespace ReactNative.Hosting.Bridge
     /// </summary>
     public class ChakraJavaScriptExecutor : IJavaScriptExecutor
     {
-        private readonly JavaScriptRuntime _runtime;
-        private readonly JavaScriptValue _globalObject;
+        private JavaScriptRuntime _runtime;
+        private JavaScriptValue _globalObject;
 
         private JavaScriptSourceContext _sourceContext = JavaScriptSourceContext.None;
 
         /// <summary>
-        /// Instantiates a <see cref="ChakraJavaScriptExecutor"/>.
+        /// Initializes the JavaScript runtime.
         /// </summary>
-        public ChakraJavaScriptExecutor()
+        /// <remarks>
+        /// Must be called from the JavaScript thread.
+        /// </remarks>
+        public void Initialize()
         {
+            if (_runtime.IsValid)
+            {
+                throw new InvalidOperationException("JavaScript runtime already initialized for this thread.");
+            }
+
             _runtime = JavaScriptRuntime.Create();
             InitializeChakra();
             _globalObject = JavaScriptValue.GlobalObject;

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -156,7 +156,7 @@
     <Compile Include="LifecycleState.cs" />
     <Compile Include="ReactInstanceManager.cs" />
     <Compile Include="ReactInstanceManagerImpl.cs" />
-    <Compile Include="CSSlayout\CSSNode.cs" />
+    <Compile Include="CSSLayout\CSSNode.cs" />
     <Compile Include="Hosting\JavaScriptBackgroundWorkItemCallback.cs" />
     <Compile Include="Hosting\JavaScriptBeforeCollectCallback.cs" />
     <Compile Include="Hosting\JavaScriptContext.cs" />
@@ -190,6 +190,8 @@
     <Compile Include="Shell\MainReactPackage.cs" />
     <Compile Include="Touch\JSResponderHandler.cs" />
     <Compile Include="Touch\OnInterceptTouchEventListener.cs" />
+    <Compile Include="UIManager\Events\Event.cs" />
+    <Compile Include="UIManager\Events\EventDispatcher.cs" />
     <Compile Include="UIManager\Events\RCTEventEmitter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Bridge\IReactBridge.cs" />
@@ -202,6 +204,7 @@
     <Compile Include="UIManager\AppRegistry.cs" />
     <Compile Include="UIManager\Events\TouchEventType.cs" />
     <Compile Include="UIManager\Events\TouchEventTypeExtensions.cs" />
+    <Compile Include="UIManager\IViewManager.cs" />
     <Compile Include="UIManager\PointerEvents.cs" />
     <Compile Include="UIManager\SizeMonitoringFrameLayout.cs" />
     <Compile Include="UIManager\NativeViewHierarchyManager.cs" />

--- a/ReactWindows/ReactNative/UIManager/Events/Event.cs
+++ b/ReactWindows/ReactNative/UIManager/Events/Event.cs
@@ -1,0 +1,151 @@
+﻿using System;
+
+namespace ReactNative.UIManager.Events
+{
+    /// <summary>
+    /// A UI event that can be dispatched to JavaScript.
+    /// </summary>
+    /// <remarks>
+    /// For dispatching events, <see cref="EventDispatcher.DispatchEvent(Event)"/>
+    /// should be used. Once the object is passed to the <see cref="EventDispatcher"/>
+    /// it should no longer be used, as <see cref="EventDispatcher"/> may
+    /// decide to recycle that object (by calling <see cref="Dispose"/>.
+    /// </remarks>
+    public abstract class Event : IDisposable
+    {
+        private bool _initialized;
+        private int _viewTag;
+        private TimeSpan _timestamp;
+
+        protected Event() { }
+
+        protected Event(int viewTag, TimeSpan timestamp)
+        {
+            Init(viewTag, timestamp);
+        }
+        
+        /// <summary>
+        /// The name of the event as registered in JavaScript.
+        /// </summary>
+        public abstract string EventName { get; }
+
+        /// <summary>
+        /// The ID of the view that generated this event.
+        /// </summary>
+        public int ViewTag
+        {
+            get
+            {
+                return _viewTag;
+            }
+        }
+
+        /// <summary>
+        /// The time at which the event happened in the 
+        /// </summary>
+        public TimeSpan Timestamp
+        {
+            get
+            {
+                return _timestamp;
+            }
+        }
+
+        /// <summary>
+        /// Signals if the event can be coalesced.
+        /// </summary>
+        /// <remarks>
+        /// Return false if the event can never be coalesced.
+        /// </remarks>
+        public virtual bool CanCoalesce
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Signals if the event has been initialized.
+        /// </summary>
+        public bool IsInitialized
+        {
+            get
+            {
+                return _initialized;
+            }
+        }
+
+        /// <summary>
+        /// A key used to determine which other events of this type this event
+        /// can be coalesced with. For example, touch move events should only
+        /// be coalesced within a single gesture, so a coalescing key there
+        /// would be the unique gesture identifier.
+        /// </summary>
+        public virtual short CoalescingKey
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Given two events, coalesce them into a single event that will be
+        /// sent to JavaScript instead of two separate events.
+        /// </summary>
+        /// <param name="otherEvent">The other event.</param>
+        /// <returns>The coalesced event.</returns>
+        /// <remarks>
+        /// By default, just chooses the one that is more recent. Two events
+        /// will only ever try to be coalesced if they have the same event
+        /// name, view ID, and coalescing key.
+        /// </remarks>
+        public virtual Event Coalesce(Event otherEvent)
+        {
+            return Timestamp > otherEvent.Timestamp ? this : otherEvent;
+        }
+
+        /// <summary>
+        /// Dispatch this event to JavaScript using the given event emitter.
+        /// </summary>
+        /// <param name="eventEmitter">The event emitter.</param>
+        public abstract void Dispatch(RCTEventEmitter eventEmitter);
+
+        /// <summary>
+        /// Disposes the event.
+        /// </summary>
+        public void Dispose()
+        {
+            _initialized = false;
+        }
+
+        /// <summary>
+        /// Initializes the event.
+        /// </summary>
+        /// <param name="viewTag">The view tag.</param>
+        /// <param name="timestamp">The timestamp.</param>
+        /// <remarks>
+        /// This method must be called before the event is sent to the event
+        /// dispatcher.
+        /// </remarks>
+        protected void Init(int viewTag, TimeSpan timestamp)
+        {
+            _viewTag = viewTag;
+            _timestamp = timestamp;
+            _initialized = true;
+        }
+
+        /// <summary>
+        /// Called when the <see cref="EventDispatcher"/> is done with an 
+        /// event, either because it was dispatched or because it was coalesced
+        /// with another <see cref="Event"/>.
+        /// </summary>
+        /// <remarks>
+        /// The derived class does not need to call this base method.
+        /// </remarks>
+        protected virtual void OnDispose()
+        {
+        }
+    }
+}

--- a/ReactWindows/ReactNative/UIManager/Events/EventDispatcher.cs
+++ b/ReactWindows/ReactNative/UIManager/Events/EventDispatcher.cs
@@ -1,0 +1,345 @@
+﻿using ReactNative.Bridge;
+using ReactNative.Tracing;
+using System;
+using System.Collections.Generic;
+
+namespace ReactNative.UIManager.Events
+{
+    /// <summary>
+    /// Class responsible for dispatching UI events to JavaScript. The main
+    /// purpose of this class is to act as an intermediary between UI code
+    /// generating events and JavaScript, making sure we don't send more events
+    /// than JavaScript can process.
+    /// 
+    /// To use it, create a subclass of <see cref="Event"/> and call
+    /// <see cref="DispatchEvent(Event)"/> whenever there is a UI event to
+    /// dispatch.
+    /// 
+    /// This class differs from the Android implementation of React as there is
+    /// no analogy to the choreographer in UWP. Instead, it is anticipated that
+    /// some other component will periodically call <see cref="OnBatchComplete"/>
+    /// to actually send the events to JavaScript.
+    /// 
+    /// If JavaScript is taking a long time processing events, then the UI
+    /// events generated on the dispatcher thread can be coalesced into fewer
+    /// events so that, when the dispatch occurs, we do not overload JavaScript
+    /// with a ton of events and cause it to get even farther behind.
+    /// 
+    /// Ideally, this is unnecessary and JavaScript is fast enough to process
+    /// all the events each frame, but this is a reasonable precautionary 
+    /// measure.
+    /// </summary>
+    /// <remarks>
+    /// Event cookies are used to coalesce events. They are made up of the
+    /// event type ID, view tag, and a custom coalescing key.
+    /// 
+    /// Event Cookie Composition:
+    /// VIEW_TAG_MASK =       0x00000000ffffffff
+    /// EVENT_TYPE_ID_MASK =  0x0000ffff00000000
+    /// COALESCING_KEY_MASK = 0xffff000000000000
+    /// </remarks>
+    public class EventDispatcher : ILifecycleEventListener
+    {
+        private static IComparer<Event> s_eventComparer = Comparer<Event>.Create((x, y) =>
+        {
+            if (x == null && y == null)
+            {
+                return 0;
+            }
+
+            if (x == null)
+            {
+                return -1;
+            }
+
+            if (y == null)
+            {
+                return 1;
+            }
+
+            var diff = x.Timestamp - y.Timestamp;
+            if (diff == TimeSpan.Zero)
+            {
+                return 0;
+            }
+            else if (diff < TimeSpan.Zero)
+            {
+                return -1;
+            }
+            else
+            {
+                return 1;
+            }
+        });
+
+        private readonly object _eventsStagingLock = new object();
+        private readonly object _eventsToDispatchLock = new object();
+
+        private readonly IList<Event> _eventStaging = new List<Event>();
+        private readonly List<Event> _eventsToDispatch = new List<Event>();
+        private readonly IDictionary<long, int> _eventCookieToLastEventIndex = new Dictionary<long, int>();
+        private readonly IDictionary<string, short> _eventNameToEventId = new Dictionary<string, short>();
+
+        private readonly ReactApplicationContext _reactContext;
+
+        private RCTEventEmitter _rctEventEmitter;
+        private bool _hasDispatchScheduled;
+        private FrameManager _currentFrameCallback;
+
+        /// <summary>
+        /// Instantiates the <see cref="EventDispatcher"/>.
+        /// </summary>
+        /// <param name="reactContext">The context.</param>
+        public EventDispatcher(ReactApplicationContext reactContext)
+        {
+            if (reactContext == null)
+                throw new ArgumentNullException(nameof(reactContext));
+
+            _reactContext = reactContext;
+            _reactContext.AddLifecycleEventListener(this);
+        }
+
+        /// <summary>
+        /// Sends the given <see cref="Event"/> to JavaScript, coalescing
+        /// events if JavaScript is backed up.
+        /// </summary>
+        /// <param name="event">The event.</param>
+        public void DispatchEvent(Event @event)
+        {
+            if (@event == null)
+                throw new ArgumentNullException(nameof(@event));
+
+            if (!@event.IsInitialized)
+            {
+                throw new ArgumentException("Dispatched event has not been initialized.", nameof(@event));
+            }
+
+            lock (_eventsStagingLock)
+            {
+                _eventStaging.Add(@event);
+            }
+        }
+
+        /// <summary>
+        /// Submits the batch of dispatched events.
+        /// </summary>
+        public void OnBatchComplete()
+        {
+            var currentFrameCallback = _currentFrameCallback;
+            if (currentFrameCallback != null)
+            {
+                currentFrameCallback.Run();
+            }
+        }
+
+        /// <summary>
+        /// Called when the host receives the resume event.
+        /// </summary>
+        public void OnResume()
+        {
+            DispatcherHelpers.AssertOnDispatcher();
+
+            if (_currentFrameCallback != null)
+            {
+                throw new InvalidOperationException("Current frame callback is not null.");
+            }
+
+            if (_rctEventEmitter == null)
+            {
+                _rctEventEmitter = _reactContext.GetJavaScriptModule<RCTEventEmitter>();
+            }
+
+            _currentFrameCallback = new FrameManager(this);
+        }
+
+        /// <summary>
+        /// Called when the host is shutting down.
+        /// </summary>
+        public void OnShutdown()
+        {
+            ClearFrameCallback();
+        }
+
+        /// <summary>
+        /// Called when the host receives the suspend event.
+        /// </summary>
+        public void OnSuspend()
+        {
+            ClearFrameCallback();
+        }
+
+        /// <summary>
+        /// Called before the catalyst instance is disposed.
+        /// </summary>
+        public void OnCatalystInstanceDispose()
+        {
+            ClearFrameCallback();
+        }
+
+        private void DispatchEvents()
+        {
+            using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "DispatchEvents"))
+            {
+                _hasDispatchScheduled = false;
+                
+                if (_rctEventEmitter == null)
+                {
+                    throw new InvalidOperationException("The RCTEventEmitter must not be null.");
+                }
+
+                lock (_eventsToDispatchLock)
+                {
+                    var n = _eventsToDispatch.Count;
+                    if (n > 1)
+                    {
+                        _eventsToDispatch.Sort(s_eventComparer);
+                    }
+
+                    for (var idx = 0; idx < n; ++idx)
+                    {
+                        var e = _eventsToDispatch[idx];
+                        if (e == null)
+                        {
+                            continue;
+                        }
+
+                        e.Dispatch(_rctEventEmitter);
+                        e.Dispose();
+                    }
+
+                    _eventsToDispatch.Clear();
+                }
+            }
+        }
+
+        private void MoveStagedEventsToDispatchQueue()
+        {
+            lock (_eventsStagingLock)
+            {
+                lock (_eventsToDispatchLock)
+                {
+                    for (var i = 0; i < _eventStaging.Count; ++i)
+                    {
+                        var e = _eventStaging[i];
+                        if (!e.CanCoalesce)
+                        {
+                            _eventsToDispatch.Add(e);
+                            continue;
+                        }
+
+                        var eventCookie = GetEventCookie(e.ViewTag, e.EventName, e.CoalescingKey);
+                        var eventToAdd = default(Event);
+                        var eventToDispose = default(Event);
+                        var lastEventIdx = default(int);
+
+                        if (!_eventCookieToLastEventIndex.TryGetValue(eventCookie, out lastEventIdx))
+                        {
+                            eventToAdd = e;
+                            _eventCookieToLastEventIndex.Add(eventCookie, _eventsToDispatch.Count);
+                        }
+                        else
+                        {
+                            var lastEvent = _eventsToDispatch[lastEventIdx];
+                            var coalescedEvent = e.Coalesce(lastEvent);
+                            if (coalescedEvent != lastEvent)
+                            {
+                                eventToAdd = coalescedEvent;
+                                _eventCookieToLastEventIndex[eventCookie] = _eventsToDispatch.Count;
+                                eventToDispose = lastEvent;
+                                _eventsToDispatch[lastEventIdx] = null;
+                            }
+                            else
+                            {
+                                eventToDispose = e;
+                            }
+                        }
+
+                        if (eventToAdd != null)
+                        {
+                            _eventsToDispatch.Add(eventToAdd);
+                        }
+
+                        if (eventToDispose != null)
+                        {
+                            eventToDispose.Dispose();
+                        }
+                    }
+                }
+
+                _eventStaging.Clear();
+            }
+        }
+
+        private long GetEventCookie(int viewTag, string eventName, short coalescingKey)
+        {
+            var eventTypeId = default(short);
+            if (!_eventNameToEventId.TryGetValue(eventName, out eventTypeId))
+            {
+                if (_eventNameToEventId.Count == short.MaxValue)
+                {
+                    throw new InvalidOperationException("Overflow of event type IDs.");
+                }
+
+                eventTypeId = (short)_eventNameToEventId.Count;
+                _eventNameToEventId.Add(eventName, eventTypeId);
+            }
+
+            return GetEventCookie(viewTag, eventTypeId, coalescingKey);
+        }
+
+        private long GetEventCookie(int viewTag, short eventTypeId, short coalescingKey)
+        {
+            return ((long)viewTag) |
+                (((long)eventTypeId) & 0xffff) << 32 |
+                (((long)coalescingKey) & 0xffff) << 48;
+        }
+
+        private void ClearFrameCallback()
+        {
+            DispatcherHelpers.AssertOnDispatcher();
+            if (_currentFrameCallback != null)
+            {
+                _currentFrameCallback.Stop();
+                _currentFrameCallback = null;
+            }
+        }
+
+        class FrameManager
+        {
+            private readonly EventDispatcher _parent;
+
+            private bool _stopped;
+
+            public FrameManager(EventDispatcher parent)
+            {
+                _parent = parent;
+            }
+
+            public void Run()
+            {
+                DispatcherHelpers.AssertOnDispatcher();
+
+                if (_stopped)
+                {
+                    return;
+                }
+
+                using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "ScheduleDispatchFrameCallback"))
+                {
+                    _parent.MoveStagedEventsToDispatchQueue();
+
+                    if (!_parent._hasDispatchScheduled)
+                    {
+                        _parent._hasDispatchScheduled = true;
+                        _parent._reactContext.RunOnJSQueueThread(_parent.DispatchEvents);
+                    }
+                }
+            }
+
+            public void Stop()
+            {
+                _stopped = true;
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative/UIManager/IViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/IViewManager.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+
+namespace ReactNative.UIManager
+{
+    /// <summary>
+    /// Base, non-generic interface for view managers.
+    /// </summary>
+    public interface IViewManager
+    {
+        /// <summary>
+        /// The name of the view manager.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// The commands map for the view manager.
+        /// </summary>
+        IReadOnlyDictionary<string, object> CommandsMap { get; }
+
+        /// <summary>
+        /// The exported custom bubbling event types.
+        /// </summary>
+        IReadOnlyDictionary<string, object> ExportedCustomBubblingEventTypeConstants { get; }
+        
+        /// <summary>
+        /// The exported custom direct event types.
+        /// </summary>
+        IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants { get; }
+
+        /// <summary>
+        /// The exported view constants.
+        /// </summary>
+        IReadOnlyDictionary<string, object> ExportedViewConstants { get; }
+
+        /// <summary>
+        /// The native properties.
+        /// </summary>
+        IReadOnlyDictionary<string, string> NativeProperties { get; }
+    }
+}

--- a/ReactWindows/ReactNative/UIManager/UIImplementation.cs
+++ b/ReactWindows/ReactNative/UIManager/UIImplementation.cs
@@ -1,7 +1,8 @@
-﻿
+﻿using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
+using ReactNative.UIManager.Events;
+using System;
 using System.Collections.Generic;
-using Windows.UI.Xaml;
 
 namespace ReactNative.UIManager
 {
@@ -18,17 +19,120 @@ namespace ReactNative.UIManager
     /// </summary>
     public class UIImplementation
     {
-        private readonly ViewManagerRegistry _ViewManagers;
-        private readonly UIViewOperationQueue _OperationsQueue;
-        private readonly ShadowNodeRegistry _ShadowNodeRegistry = new ShadowNodeRegistry();
+        private readonly ViewManagerRegistry _viewManagers;
+        private readonly UIViewOperationQueue _operationsQueue;
+        private readonly ShadowNodeRegistry _shadowNodeRegistry = new ShadowNodeRegistry();
 
         public UIImplementation(
             ReactApplicationContext reactContext, 
-            IReadOnlyList<ViewManager<FrameworkElement, ReactShadowNode>> viewManagers)
+            IReadOnlyList<IViewManager> viewManagers)
         {
-            _ViewManagers = new ViewManagerRegistry(viewManagers);
-            _OperationsQueue = new UIViewOperationQueue(reactContext, new NativeViewHierarchyManager(_ViewManagers));
+            _viewManagers = new ViewManagerRegistry(viewManagers);
+            _operationsQueue = new UIViewOperationQueue(reactContext, new NativeViewHierarchyManager(_viewManagers));
         }
-        
+
+        /// <summary>
+        /// Called when the host receives the suspend event.
+        /// </summary>
+        public void OnSuspend()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Called when the host receives the resume event.
+        /// </summary>
+        public void OnResume()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Called when the host is shutting down.
+        /// </summary>
+        public void OnShutdown()
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void DispatchViewUpdates(EventDispatcher _eventDispatcher, int batchId)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void ConfigureNextLayoutAnimation(Dictionary<string, object> config, ICallback success, ICallback error)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void SetLayoutAnimationEnabledExperimental(bool enabled)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void ShowPopupMenu(int reactTag, JArray items, ICallback error, ICallback success)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void DispatchViewManagerCommand(int reactTag, int commandId, JArray commandArgs)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void RemoveRootView(int rootViewTag)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void ClearJavaScriptResponder()
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void SetJavaScriptResponder(int reactTag, bool blockNativeResponder)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void CreateView(int tag, string className, int rootViewTag, JObject props)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void UpdateView(int tag, string className, JObject props)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void ManageChildren(int viewTag, JArray moveFrom, JArray moveTo, JArray addChildTags, JArray addAtIndices, JArray removeFrom)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void ReplaceExistingNonRootView(int oldTag, int newTag)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void RemoveSubviewsFromContainerWithID(int containerTag)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void Measure(int reactTag, ICallback callback)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void MeasureLayout(int tag, int ancestorTag, ICallback errorCallback, ICallback successCallback)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal void MeasureLayoutRelativeToParent(int tag, ICallback errorCallback, ICallback successCallback)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/ReactWindows/ReactNative/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative/UIManager/UIManagerModule.cs
@@ -1,35 +1,83 @@
-﻿
+﻿using Newtonsoft.Json.Linq;
 using ReactNative.Bridge;
-using ReactNative.UIManager;
+using ReactNative.Tracing;
+using ReactNative.UIManager.Events;
 using ReactNative.Views;
+using System;
 using System.Collections.Generic;
-using Windows.UI.Xaml;
 
 namespace ReactNative.UIManager
 {
     /// <summary>
     /// Native module to allow JS to create and update native Views.
     /// </summary>
-    public partial class UIManagerModule : NativeModuleBase
+    /// <remarks>
+    /// TODO: 
+    /// 1) Add animation support to UIManagerModule
+    /// 2) Implement `findSubviewIn` ReactMethod
+    /// </remarks>
+    public partial class UIManagerModule : ReactContextNativeModuleBase, ILifecycleEventListener, IOnBatchCompleteListener
     {
         private readonly UIImplementation _uiImplementation;
-        private readonly IDictionary<string, object> _moduleConstants;
+        private readonly IReadOnlyDictionary<string, object> _moduleConstants;
+        private readonly EventDispatcher _eventDispatcher;
 
-        private int nextRootTag = 1;
+        private int _batchId;
+        private int _nextRootTag = 1;
 
-        public UIManagerModule(ReactApplicationContext reactContext,
-                               IReadOnlyList<ViewManager<FrameworkElement, ReactShadowNode>> viewManagerList,
-                               UIImplementation uiImplementation)
+        /// <summary>
+        /// Instantiates a <see cref="UIManagerModule"/>.
+        /// </summary>
+        /// <param name="reactContext">The react context.</param>
+        /// <param name="viewManagers">The view managers.</param>
+        /// <param name="uiImplementation">The UI implementation.</param>
+        public UIManagerModule(
+            ReactApplicationContext reactContext,
+            IReadOnlyList<IViewManager> viewManagers,
+            UIImplementation uiImplementation)
+            : base(reactContext)
         {
+            if (viewManagers == null)
+                throw new ArgumentNullException(nameof(viewManagers));
+            if (uiImplementation == null)
+                throw new ArgumentNullException(nameof(uiImplementation));
+
+            _eventDispatcher = new EventDispatcher(reactContext);
             _uiImplementation = uiImplementation;
-            //_moduleConstants = CreateConstants(viewManagerList);
+            _moduleConstants = CreateConstants(viewManagers);
+            reactContext.AddLifecycleEventListener(this);
         }
 
+        /// <summary>
+        /// The name of the module.
+        /// </summary>
         public override string Name
         {
             get
             {
                 return "RKUIManager";
+            }
+        }
+
+        /// <summary>
+        /// The constants exported by this module.
+        /// </summary>
+        public override IReadOnlyDictionary<string, object> Constants
+        {
+            get
+            {
+                return _moduleConstants;
+            }
+        }
+
+        /// <summary>
+        /// The event dispatcher for the module.
+        /// </summary>
+        public EventDispatcher EventDispatcher
+        {
+            get
+            {
+                return _eventDispatcher;
             }
         }
 
@@ -45,11 +93,310 @@ namespace ReactNative.UIManager
         /// <returns></returns>
         public int AddMeasuredRootView(ReactRootView rootView)
         {
-            var tag = nextRootTag;
-            nextRootTag += 10;
-            rootView.BindTagToView(nextRootTag);
+            var tag = _nextRootTag;
+            _nextRootTag += 10;
+            rootView.BindTagToView(_nextRootTag);
 
             return tag;
         }
+
+        #region React Methods
+
+        /// <summary>
+        /// Removes the root view.
+        /// </summary>
+        /// <param name="rootViewTag">The root view tag.</param>
+        [ReactMethod]
+        public void removeRootView(int rootViewTag)
+        {
+            _uiImplementation.RemoveRootView(rootViewTag);
+        }
+
+        /// <summary>
+        /// Creates a view.
+        /// </summary>
+        /// <param name="tag">The view tag.</param>
+        /// <param name="className">The class name.</param>
+        /// <param name="rootViewTag">The root view tag.</param>
+        /// <param name="props">The properties.</param>
+        [ReactMethod]
+        public void createView(int tag, string className, int rootViewTag, JObject props)
+        {
+            _uiImplementation.CreateView(tag, className, rootViewTag, props);
+        }
+
+        /// <summary>
+        /// Updates a view.
+        /// </summary>
+        /// <param name="tag">The view tag.</param>
+        /// <param name="className">The class name.</param>
+        /// <param name="props">The properties.</param>
+        [ReactMethod]
+        public void updateView(int tag, string className, JObject props)
+        {
+            _uiImplementation.UpdateView(tag, className, props);
+        }
+
+        /// <summary>
+        /// Manage the children of a view.
+        /// </summary>
+        /// <param name="viewTag">The view tag of the parent view.</param>
+        /// <param name="moveFrom">
+        /// A list of indices in the parent view to move views from.
+        /// </param>
+        /// <param name="moveTo">
+        /// A list of indices in the parent view to move views to.
+        /// </param>
+        /// <param name="addChildTags">
+        /// A list of tags of views to add to the parent.
+        /// </param>
+        /// <param name="addAtIndices">
+        /// A list of indices to insert the child tags at.
+        /// </param>
+        /// <param name="removeFrom">
+        /// A list of indices to permanently remove. The memory for the
+        /// corresponding views and data structures should be reclaimed.
+        /// </param>
+        [ReactMethod]
+        public void manageChildren(
+            int viewTag,
+            JArray moveFrom,
+            JArray moveTo,
+            JArray addChildTags,
+            JArray addAtIndices,
+            JArray removeFrom)
+        {
+            _uiImplementation.ManageChildren(
+                viewTag,
+                moveFrom,
+                moveTo,
+                addChildTags,
+                addAtIndices,
+                removeFrom);
+        }
+
+        /// <summary>
+        /// Replaces the view specified by the <paramref name="oldtag"/> with
+        /// the view specified by <paramref name="newTag"/> within
+        /// <paramref name="oldTag"/>'s parent. This resolves to a simple 
+        /// <see cref="manageChildren(int, JArray, JArray, JArray, JArray, JArray)"/>
+        /// call, but React does not have enough information in JavaScript to
+        /// formulate it itself.
+        /// </summary>
+        /// <param name="oldTag">The old view tag.</param>
+        /// <param name="newTag">The new view tag.</param>
+        [ReactMethod]
+        public void replaceExistingNonRootView(int oldTag, int newTag)
+        {
+            _uiImplementation.ReplaceExistingNonRootView(oldTag, newTag);
+        }
+
+        /// <summary>
+        /// Method which takes a container tag and then releases all subviews
+        /// for that container upon receipt.
+        /// </summary>
+        /// <param name="containerTag">The container tag.</param>
+        [ReactMethod]
+        public void removeSubviewsFromContainerWithID(int containerTag)
+        {
+            _uiImplementation.RemoveSubviewsFromContainerWithID(containerTag);
+        }
+
+        /// <summary>
+        /// Determines the location on screen, width, and height of the given
+        /// view and returns the values via an asynchronous callback.
+        /// </summary>
+        /// <param name="reactTag">The view tag to measure.</param>
+        /// <param name="callback">The callback.</param>
+        [ReactMethod]
+        public void measure(int reactTag, ICallback callback)
+        {
+            _uiImplementation.Measure(reactTag, callback);
+        }
+
+        /// <summary>
+        /// Measure the view specified by <paramref name="tag"/> to the given
+        /// <paramref name="ancestorTag"/>. This means that the returned x, y
+        /// are relative to the origin x, y of the ancestor view.
+        /// </summary>
+        /// <param name="tag">The view tag.</param>
+        /// <param name="ancestorTag">The ancestor tag.</param>
+        /// <param name="errorCallback">The error callback.</param>
+        /// <param name="successCallback">The success callback.</param>
+        /// <remarks>
+        /// NB: Unlike <see cref="measure(int, ICallback)"/>, this will measure
+        /// relative to the view layout, not the visible window which can cause
+        /// unexpected results when measuring relative to things like scroll
+        /// views that can have offset content on the screen.
+        /// </remarks>
+        [ReactMethod]
+        public void measureLayout(
+            int tag,
+            int ancestorTag,
+            ICallback errorCallback,
+            ICallback successCallback)
+        {
+            _uiImplementation.MeasureLayout(tag, ancestorTag, errorCallback, successCallback);
+        }
+
+        /// <summary>
+        /// Like <see cref="measure(int, ICallback)"/> and
+        /// <see cref="measureLayout(int, int, ICallback, ICallback)"/> but
+        /// measures relative to the immediate parent.
+        /// </summary>
+        /// <param name="tag">The view tag to measure.</param>
+        /// <param name="errorCallback">The error callback.</param>
+        /// <param name="successCallback">The success callback.</param>
+        /// <remarks>
+        /// NB: Unlike <see cref="measure(int, ICallback)"/>, this will measure
+        /// relative to the view layout, not the visible window which can cause
+        /// unexpected results when measuring relative to things like scroll
+        /// views that can have offset content on the screen.
+        /// </remarks>
+        [ReactMethod]
+        public void measureLayoutRelativeToParent(
+            int tag,
+            ICallback errorCallback,
+            ICallback successCallback)
+        {
+            _uiImplementation.MeasureLayoutRelativeToParent(tag, errorCallback, successCallback);
+        }
+
+        /// <summary>
+        /// Sets a JavaScript responder for a view.
+        /// </summary>
+        /// <param name="reactTag">The view ID.</param>
+        /// <param name="blockNativeResponder">
+        /// Flag to signal if the native responder should be blocked.
+        /// </param>
+        [ReactMethod]
+        public void setJSResponder(int reactTag, bool blockNativeResponder)
+        {
+            _uiImplementation.SetJavaScriptResponder(reactTag, blockNativeResponder);
+        }
+
+        /// <summary>
+        /// Clears the JavaScript responder.
+        /// </summary>
+        [ReactMethod]
+        public void clearJSResponder()
+        {
+            _uiImplementation.ClearJavaScriptResponder();
+        }
+
+        /// <summary>
+        /// Dispatches a command to the view manager.
+        /// </summary>
+        /// <param name="reactTag">The tag of the view manager.</param>
+        /// <param name="commandId">The command ID.</param>
+        /// <param name="commandArgs">The command arguments.</param>
+        [ReactMethod]
+        public void dispatchViewManagerCommand(int reactTag, int commandId, JArray commandArgs)
+        {
+            _uiImplementation.DispatchViewManagerCommand(reactTag, commandId, commandArgs);
+        }
+
+        /// <summary>
+        /// Show a pop-up menu.
+        /// </summary>
+        /// <param name="reactTag">
+        /// The tag of the anchor view (the pop-up menu is displayed next to
+        /// this view); this needs to be the tag of a native view (shadow views
+        /// cannot be anchors).
+        /// </param>
+        /// <param name="items">The menu items as an array of strings.</param>
+        /// <param name="error">
+        /// Callback used if there is an error displaying the menu.
+        /// </param>
+        /// <param name="success">
+        /// Callback used with the position of the selected item as the first
+        /// argument, or no arguments if the menu is dismissed.
+        /// </param>
+        [ReactMethod]
+        public void showPopupMenu(int reactTag, JArray items, ICallback error, ICallback success)
+        {
+            _uiImplementation.ShowPopupMenu(reactTag, items, error, success);
+        }
+
+        /// <summary>
+        /// Configure an animation to be used for the native layout changes,
+        /// and native views creation. The animation will only apply during the
+        /// current batch operations.
+        /// </summary>
+        /// <param name="config">
+        /// The configuration of the animation for view addition/removal/update.
+        /// </param>
+        /// <param name="success">
+        /// Callback used when the animation completes, or when the animation
+        /// gets interrupted. In this case, the callback parameter will be false.
+        /// </param>
+        /// <param name="error">
+        /// Callback used if there was an error processing the animation.
+        /// </param>
+        [ReactMethod]
+        public void configureNextLayoutAnimation(Dictionary<string, object> config, ICallback success, ICallback error)
+        {
+            _uiImplementation.ConfigureNextLayoutAnimation(config, success, error);
+        }
+
+        #endregion
+
+        #region ILifecycleEventListener
+
+        /// <summary>
+        /// Called when the host receives the suspend event.
+        /// </summary>
+        public void OnSuspend()
+        {
+            _uiImplementation.OnSuspend();
+        }
+
+        /// <summary>
+        /// Called when the host receives the resume event.
+        /// </summary>
+        public void OnResume()
+        {
+            _uiImplementation.OnResume();
+        }
+
+        /// <summary>
+        /// Called when the host is shutting down.
+        /// </summary>
+        public void OnShutdown()
+        {
+            _uiImplementation.OnShutdown();
+        }
+
+        #endregion
+
+        #region IOnBatchCompleteListener
+
+        /// <summary>
+        /// To implement the transactional requirement, UI changes are only
+        /// committed to the actual view hierarchy once a batch of JavaScript
+        /// to native calls have been completed.
+        /// </summary>
+        public void OnBatchComplete()
+        {
+            var batchId = _batchId++;
+
+            using (Tracer.Trace(Tracer.TRACE_TAG_REACT_BRIDGE, "onBatchCompleteUI")
+                .With("BatchId", batchId))
+            {
+                _uiImplementation.DispatchViewUpdates(_eventDispatcher, batchId);
+            }
+        }
+
+        #endregion
+
+        #region NativeModuleBase
+
+        public override void OnCatalystInstanceDispose()
+        {
+            base.OnCatalystInstanceDispose();
+            _eventDispatcher.OnCatalystInstanceDispose();
+        }
+
+        #endregion
     }
 }

--- a/ReactWindows/ReactNative/UIManager/ViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/ViewManager.cs
@@ -1,8 +1,11 @@
-﻿using Windows.UI.Xaml;
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using Windows.UI.Xaml;
 
 namespace ReactNative.UIManager
 {
-    public abstract class ViewManager<T, C> 
+    public abstract class ViewManager<T, C> : IViewManager
         where T : FrameworkElement
         where C : ReactShadowNode
     {
@@ -19,6 +22,8 @@ namespace ReactNative.UIManager
             return view;
         }*/
 
+        public abstract void ReceiveCommand(T root, int commandId, JArray args);
+
         /// <summary>
         /// Subclasses should return a new View instance of the proper type.
         /// </summary>
@@ -27,10 +32,30 @@ namespace ReactNative.UIManager
         protected abstract T createViewInstance(ThemedReactContext reactContext);
 
         /// <summary>
-        /// the name of this view manager. This will be the name used to reference this view manager from JavaScript in createReactNativeComponentClass.
+        /// The name of this view manager. This will be the name used to 
+        /// reference this view manager from JavaScript.
         /// </summary>
-        /// <returns></returns>
-        public abstract string getName();
+        public abstract string Name { get; }
+
+        /// <summary>
+        /// The commands map for the view manager.
+        /// </summary>
+        /// <remarks>
+        /// Subclasses of <see cref="ViewManager{T, C}"/> that expect to
+        /// receive commands through commands dispatched from
+        /// <see cref="UIManagerModule"/> should override this method returning
+        /// the map between names of the commands and identifiers that are then
+        /// used in the <see cref="R"/>
+        /// </remarks>
+        public abstract IReadOnlyDictionary<string, object> CommandsMap { get; }
+
+        public abstract IReadOnlyDictionary<string, object> ExportedCustomBubblingEventTypeConstants { get; }
+
+        public abstract IReadOnlyDictionary<string, object> ExportedCustomDirectEventTypeConstants { get; }
+
+        public abstract IReadOnlyDictionary<string, object> ExportedViewConstants { get; }
+
+        public abstract IReadOnlyDictionary<string, string> NativeProperties { get; }
 
         /// <summary>
         /// Called when view is detached from view hierarchy and allows for some additional cleanup by the {@link ViewManager} subclass.
@@ -49,14 +74,5 @@ namespace ReactNative.UIManager
         protected void addEventEmitters(ThemedReactContext reactContext, T view)
         {
         }
-
-        /// <summary>
-        /// Returns a dictoinary of view-specific constants that are injected to JavaScript. These constants are made accessible via UIManager.<ViewName>.Constants.
-        /// </summary>
-        /// <returns></returns>
-        /*public Dictionary<string, string> getNativeProps()
-        {
-            return ViewManagersPropertyCache.getNativePropsForView(getClass(), getShadowNodeClass());
-        }*/
     }
 }

--- a/ReactWindows/ReactNative/UIManager/ViewManagerRegistry.cs
+++ b/ReactWindows/ReactNative/UIManager/ViewManagerRegistry.cs
@@ -8,18 +8,18 @@ namespace ReactNative.UIManager
 
     public class ViewManagerRegistry
     {
-        private readonly Dictionary<string, ViewManager<FrameworkElement, ReactShadowNode>> mViewManagers = new Dictionary<string, ViewManager<FrameworkElement, ReactShadowNode>>();
+        private readonly Dictionary<string, IViewManager> mViewManagers =
+            new Dictionary<string, IViewManager>();
 
-        public ViewManagerRegistry(
-            IReadOnlyList<ViewManager<FrameworkElement, ReactShadowNode>> viewManagerList)
+        public ViewManagerRegistry(IReadOnlyList<IViewManager> viewManagerList)
         {
             foreach (var viewManager in viewManagerList)
             {
-                mViewManagers.Add(viewManager.getName(), viewManager);
+                mViewManagers.Add(viewManager.Name, viewManager);
             }
         }
 
-        public ViewManager<FrameworkElement, ReactShadowNode> get(String className)
+        public IViewManager get(string className)
         {
             var viewManager = mViewManagers[className];
             if (viewManager != null)


### PR DESCRIPTION
Also adds two-phase initialization of the ChakraJavaScriptExecutor so the instance can be created off the JavaScript thread.

Also fixes a bug with the UIManagerModule constants and adds unit tests for custom event types and constant overloading by view managers.

Also adds a simple base interface (IViewManager) for view managers to hold names and constants.