### PR TITLE
Fixes #112 - Adds logic to drain Events/EventDispatcher

### DIFF
--- a/ReactWindows/ReactNative.Tests/Internal/MockEvent.cs
+++ b/ReactWindows/ReactNative.Tests/Internal/MockEvent.cs
@@ -8,12 +8,24 @@ namespace ReactNative.Tests
     {
         private readonly string _eventName;
         private readonly JObject _eventArgs;
+        private readonly Action _onDispose;
+
+        public MockEvent(int viewTag, TimeSpan timestamp, string eventName)
+            : this(viewTag, timestamp, eventName, new JObject())
+        {
+        }
 
         public MockEvent(int viewTag, TimeSpan timestamp, string eventName, JObject eventArgs)
+            : this(viewTag, timestamp, eventName, eventArgs, () => { })
+        {
+        }
+
+        public MockEvent(int viewTag, TimeSpan timestamp, string eventName, JObject eventArgs, Action onDispose)
             : base(viewTag, timestamp)
         {
             _eventName = eventName;
             _eventArgs = eventArgs;
+            _onDispose = onDispose;
         }
 
         public override string EventName
@@ -27,6 +39,11 @@ namespace ReactNative.Tests
         public override void Dispatch(RCTEventEmitter eventEmitter)
         {
             eventEmitter.receiveEvent(ViewTag, EventName, _eventArgs);
+        }
+
+        protected override void OnDispose()
+        {
+            _onDispose();
         }
     }
 }

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/EventDispatcherTests.cs
@@ -4,6 +4,7 @@ using ReactNative.Bridge;
 using ReactNative.Bridge.Queue;
 using ReactNative.UIManager.Events;
 using System;
+using System.Reactive.Disposables;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,10 +38,10 @@ namespace ReactNative.Tests.UIManager.Events
         [TestMethod]
         public async Task EventDispatcher_EventDispatches()
         {
-            var eventHandler = new AutoResetEvent(false);
+            var dispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
             {
-                eventHandler.Set();
+                dispatched.Set();
                 return default(JToken);
             });
 
@@ -48,20 +49,189 @@ namespace ReactNative.Tests.UIManager.Events
             var dispatcher = new EventDispatcher(context);
             await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
 
-            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo", new JObject());
+            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo");
             dispatcher.DispatchEvent(testEvent);
-            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnBatchComplete);
 
-            Assert.IsTrue(eventHandler.WaitOne());
+            Assert.IsTrue(dispatched.WaitOne());
+        }
+
+        [TestMethod]
+        public async Task EventDispatcher_NonCoalesced()
+        {
+            var waitDispatched = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                waitDispatched.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var e1 = new NonCoalescedEvent(42, TimeSpan.Zero, "Foo");
+            var e2 = new NonCoalescedEvent(42, TimeSpan.Zero, "Foo");
+
+            using (BlockJavaScriptThread(context))
+            {
+                dispatcher.DispatchEvent(e1);
+                dispatcher.DispatchEvent(e2);
+            }
+
+            Assert.IsTrue(waitDispatched.WaitOne());
+            Assert.IsTrue(waitDispatched.WaitOne());
+        }
+
+        [TestMethod]
+        public async Task EventDispatcher_MultipleDispatches()
+        {
+            var waitDispatched = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                waitDispatched.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var count = 100;
+            for (var i = 0; i < count; ++i)
+            {
+                var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo");
+                dispatcher.DispatchEvent(testEvent);
+                Assert.IsTrue(waitDispatched.WaitOne());
+            }
+        }
+
+        [TestMethod]
+        public async Task EventDispatcher_EventsCoalesced1()
+        {
+            var waitDispatched = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                waitDispatched.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var winner = default(int);
+            var disposed = new AutoResetEvent(false);
+
+            var firstEvent = new TestEvent(42, TimeSpan.Zero, "foo", 1, () => winner = 1, () => disposed.Set());
+            var secondEvent = new TestEvent(42, TimeSpan.MaxValue, "foo", 1, () => winner = 2, () => disposed.Set());
+
+            using (BlockJavaScriptThread(context))
+            {
+                dispatcher.DispatchEvent(firstEvent);
+                dispatcher.DispatchEvent(secondEvent);
+
+                // First event is disposed after coalesce
+                Assert.IsTrue(disposed.WaitOne());
+            }
+
+            Assert.IsTrue(waitDispatched.WaitOne());
+            Assert.AreEqual(2, winner);
+            Assert.IsFalse(waitDispatched.WaitOne(500));
+
+            // Second event is disposed after dispatch
+            Assert.IsTrue(disposed.WaitOne()); 
+        }
+
+        [TestMethod]
+        public async Task EventDispatcher_EventsCoalesced2()
+        {
+            var waitDispatched = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                waitDispatched.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var winner = default(int);
+            var disposed = new AutoResetEvent(false);
+
+            var firstEvent = new TestEvent(42, TimeSpan.MaxValue, "foo", 1, () => winner = 1, () => disposed.Set());
+            var secondEvent = new TestEvent(42, TimeSpan.Zero, "foo", 1, () => winner = 2, () => disposed.Set());
+
+            using (BlockJavaScriptThread(context))
+            {
+                dispatcher.DispatchEvent(firstEvent);
+                dispatcher.DispatchEvent(secondEvent);
+
+                // First event is disposed after coalesce
+                Assert.IsTrue(disposed.WaitOne());
+            }
+
+            Assert.IsTrue(waitDispatched.WaitOne());
+            Assert.AreEqual(1, winner);
+            Assert.IsFalse(waitDispatched.WaitOne(500));
+
+            // Second event is disposed after dispatch
+            Assert.IsTrue(disposed.WaitOne());
+        }
+
+
+        [TestMethod]
+        public async Task EventDispatcher_EventsNotCoalesced()
+        {
+            var waitDispatched = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                waitDispatched.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var disposed = new AutoResetEvent(false);
+
+            var diffTag1 = new TestEvent(42, TimeSpan.Zero, "foo", 1);
+            var diffTag2 = new TestEvent(43, TimeSpan.Zero, "foo", 1);
+
+            var diffName1 = new TestEvent(42, TimeSpan.Zero, "foo", 1);
+            var diffName2 = new TestEvent(42, TimeSpan.Zero, "bar", 1);
+
+            var diffKey1 = new TestEvent(42, TimeSpan.Zero, "foo", 1);
+            var diffKey2 = new TestEvent(42, TimeSpan.Zero, "foo", 2);
+
+            var pairs = new[]
+            {
+                new[] { diffTag1, diffTag2 },
+                new[] { diffName1, diffName2 },
+                new[] { diffKey1, diffKey2 },
+            };
+
+            foreach (var pair in pairs)
+            {
+                using (BlockJavaScriptThread(context))
+                {
+                    dispatcher.DispatchEvent(pair[0]);
+                    dispatcher.DispatchEvent(pair[1]);
+                }
+
+                Assert.IsTrue(waitDispatched.WaitOne());
+                Assert.IsTrue(waitDispatched.WaitOne());
+            }
         }
 
         [TestMethod]
         public async Task EventDispatcher_OnSuspend_EventDoesNotDispatch()
         {
-            var eventHandler = new AutoResetEvent(false);
+            var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
             {
-                eventHandler.Set();
+                waitDispatched.Set();
                 return default(JToken);
             });
 
@@ -69,21 +239,24 @@ namespace ReactNative.Tests.UIManager.Events
             var dispatcher = new EventDispatcher(context);
             await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
 
-            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo", new JObject());
-            dispatcher.DispatchEvent(testEvent);
-            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnSuspend);
-            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnBatchComplete);
+            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo");
 
-            Assert.IsFalse(eventHandler.WaitOne(500));
+            using (BlockJavaScriptThread(context))
+            {
+                dispatcher.DispatchEvent(testEvent);
+                await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnSuspend);
+            }
+
+            Assert.IsFalse(waitDispatched.WaitOne(500));
         }
 
         [TestMethod]
         public async Task EventDispatcher_OnShutdown_EventDoesNotDispatch()
         {
-            var eventHandler = new AutoResetEvent(false);
+            var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
             {
-                eventHandler.Set();
+                waitDispatched.Set();
                 return default(JToken);
             });
 
@@ -91,21 +264,24 @@ namespace ReactNative.Tests.UIManager.Events
             var dispatcher = new EventDispatcher(context);
             await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
 
-            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo", new JObject());
-            dispatcher.DispatchEvent(testEvent);
-            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnShutdown);
-            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnBatchComplete);
+            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo");
 
-            Assert.IsFalse(eventHandler.WaitOne(500));
+            using (BlockJavaScriptThread(context))
+            {
+                dispatcher.DispatchEvent(testEvent);
+                await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnShutdown);
+            }
+
+            Assert.IsFalse(waitDispatched.WaitOne(500));
         }
 
         [TestMethod]
         public async Task EventDispatcher_OnCatalystInstanceDispose_EventDoesNotDispatch()
         {
-            var eventHandler = new AutoResetEvent(false);
+            var waitDispatched = new AutoResetEvent(false);
             var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
             {
-                eventHandler.Set();
+                waitDispatched.Set();
                 return default(JToken);
             });
 
@@ -113,12 +289,40 @@ namespace ReactNative.Tests.UIManager.Events
             var dispatcher = new EventDispatcher(context);
             await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
 
-            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo", new JObject());
-            dispatcher.DispatchEvent(testEvent);
-            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnCatalystInstanceDispose);
-            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnBatchComplete);
+            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo");
 
-            Assert.IsFalse(eventHandler.WaitOne(500));
+            using (BlockJavaScriptThread(context))
+            {
+                dispatcher.DispatchEvent(testEvent);
+                await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnCatalystInstanceDispose);
+            }
+
+            Assert.IsFalse(waitDispatched.WaitOne(500));
+        }
+
+        [TestMethod]
+        public async Task EventDispatcher_DispatchedAfterSuspend_ThenResume()
+        {
+            var waitDispatched = new AutoResetEvent(false);
+            var executor = new MockJavaScriptExecutor((p0, p1, p2) =>
+            {
+                waitDispatched.Set();
+                return default(JToken);
+            });
+
+            var context = await CreateContextAsync(executor);
+            var dispatcher = new EventDispatcher(context);
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+
+            var testEvent = new MockEvent(42, TimeSpan.Zero, "Foo");
+
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnSuspend);
+            dispatcher.DispatchEvent(testEvent);
+
+            Assert.IsFalse(waitDispatched.WaitOne(500));
+
+            await DispatcherHelpers.RunOnDispatcherAsync(dispatcher.OnResume);
+            Assert.IsTrue(waitDispatched.WaitOne());
         }
 
         private static async Task<ReactApplicationContext> CreateContextAsync(IJavaScriptExecutor executor)
@@ -155,6 +359,74 @@ namespace ReactNative.Tests.UIManager.Events
         private static Task InitializeCatalystInstanceAsync(CatalystInstance catalystInstance)
         {
             return catalystInstance.InitializeBridgeAsync();
+        }
+
+        private static IDisposable BlockJavaScriptThread(ReactContext reactContext)
+        {
+            var enter = new AutoResetEvent(false);
+            var exit = new AutoResetEvent(false);
+
+            reactContext.RunOnJSQueueThread(() =>
+            {
+                enter.Set();
+                exit.WaitOne();
+            });
+
+            enter.WaitOne();
+            return Disposable.Create(() => exit.Set());
+        }
+
+        class NonCoalescedEvent : MockEvent
+        {
+            public NonCoalescedEvent(int viewTag, TimeSpan timestamp, string eventName)
+                : base(viewTag, timestamp, eventName)
+            {
+            }
+
+            public override bool CanCoalesce
+            {
+                get
+                {
+                    return false;
+                }
+            }
+        }
+
+        class TestEvent : MockEvent
+        {
+            private readonly Action _onDispatched;
+
+            public TestEvent(
+                int viewTag,
+                TimeSpan timestamp,
+                string eventName,
+                short coalescingKey)
+                : this(viewTag, timestamp, eventName, coalescingKey, () => { }, () => { })
+            {
+            }
+
+            public TestEvent(
+                int viewTag, 
+                TimeSpan timestamp,
+                string eventName, 
+                short coalescingKey,
+                Action onDispatched,
+                Action onDispose)
+                : base(viewTag, timestamp, eventName, new JObject(), onDispose)
+            {
+                _onDispatched = onDispatched;
+
+                CoalescingKey = coalescingKey;
+            }
+
+            public override short CoalescingKey { get; }
+
+            public override void Dispatch(RCTEventEmitter eventEmitter)
+            {
+                _onDispatched();
+
+                base.Dispatch(eventEmitter);
+            }
         }
     }
 }

--- a/ReactWindows/ReactNative.Tests/UIManager/Events/EventTests.cs
+++ b/ReactWindows/ReactNative.Tests/UIManager/Events/EventTests.cs
@@ -10,8 +10,9 @@ namespace ReactNative.Tests.UIManager.Events
         [TestMethod]
         public void Event_Initialize_Dispose()
         {
-            var e = new MockEvent(42, TimeSpan.FromSeconds(10), "Test", new JObject());
+            var e = new MockEvent(42, TimeSpan.FromSeconds(10), "Test");
 
+            Assert.IsTrue(e.CanCoalesce);
             Assert.IsTrue(e.IsInitialized);
 
             Assert.AreEqual(42, e.ViewTag);

--- a/ReactWindows/ReactNative/UIManager/Events/Event.cs
+++ b/ReactWindows/ReactNative/UIManager/Events/Event.cs
@@ -118,6 +118,7 @@ namespace ReactNative.UIManager.Events
         public void Dispose()
         {
             _initialized = false;
+            OnDispose();
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/UIManager/UIManagerModule.cs
+++ b/ReactWindows/ReactNative/UIManager/UIManagerModule.cs
@@ -395,9 +395,6 @@ namespace ReactNative.UIManager
                     _uiImplementation.DispatchViewUpdates(_eventDispatcher, batchId);
                 }
             });
-
-            // TODO: coordinate with UI operations a la choreographer?
-            _eventDispatcher.OnBatchComplete();
         }
 
         #endregion


### PR DESCRIPTION
Previously, we relied on the OnBatchComplete method to drain the EventDispatcher. However, this is insufficient, as all dispatched events may not be sourced from a batch of native module calls. For example, events are also dispatched directly from view instances.