### PR TITLE
Fixes #31 - Adds idle/busy events to the CatalystInstance for JavaScript

### DIFF
--- a/ReactWindows/ReactNative/Bridge/BridgeBusyEventArgs.cs
+++ b/ReactWindows/ReactNative/Bridge/BridgeBusyEventArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// Event arguments sent when a <see cref="CatalystInstance"/> is busy.
+    /// </summary>
+    public class BridgeBusyEventArgs : EventArgs
+    {
+    }
+}

--- a/ReactWindows/ReactNative/Bridge/BridgeIdleEventArgs.cs
+++ b/ReactWindows/ReactNative/Bridge/BridgeIdleEventArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace ReactNative.Bridge
+{
+    /// <summary>
+    /// Event arguments sent when a <see cref="CatalystInstance"/> is idle.
+    /// </summary>
+    public class BridgeIdleEventArgs : EventArgs
+    {
+    }
+}

--- a/ReactWindows/ReactNative/Bridge/IReactBridge.cs
+++ b/ReactWindows/ReactNative/Bridge/IReactBridge.cs
@@ -30,5 +30,11 @@ namespace ReactNative.Bridge
         /// <param name="propertyName">The property name.</param>
         /// <param name="jsonEncodedArgument">The JSON-encoded value.</param>
         void SetGlobalVariable(string propertyName, string jsonEncodedArgument);
+
+        /// <summary>
+        /// Evaluates JavaScript.
+        /// </summary>
+        /// <param name="script">The script.</param>
+        void RunScript(string script);
     }
 }

--- a/ReactWindows/ReactNative/Bridge/JavaScriptBundleLoader.cs
+++ b/ReactWindows/ReactNative/Bridge/JavaScriptBundleLoader.cs
@@ -28,7 +28,7 @@ namespace ReactNative.Bridge
         /// Loads the bundle into a JavaScript executor.
         /// </summary>
         /// <param name="executor">The JavaScript executor.</param>
-        public abstract void LoadScript(IJavaScriptExecutor executor);
+        public abstract void LoadScript(IReactBridge executor);
 
         /// <summary>
         /// This loader will read the file from the project directory.
@@ -75,7 +75,7 @@ namespace ReactNative.Bridge
                 }
             }
 
-            public override void LoadScript(IJavaScriptExecutor executor)
+            public override void LoadScript(IReactBridge bridge)
             {
                 if (_script == null)
                 {
@@ -84,7 +84,7 @@ namespace ReactNative.Bridge
 
                 try
                 {
-                    executor.RunScript(_script);
+                    bridge.RunScript(_script);
                 }
                 catch (Exception ex)
                 {

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -108,6 +108,8 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Bridge\BridgeBusyEventArgs.cs" />
+    <Compile Include="Bridge\BridgeIdleEventArgs.cs" />
     <Compile Include="Bridge\ILifecycleEventListener.cs" />
     <Compile Include="Bridge\IPromise.cs" />
     <Compile Include="Bridge\CatalystInstance.cs" />
@@ -284,10 +286,7 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="JavaScript\lib\" />
-    <Folder Include="JavaScript\uwp-native\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <Reference Include="Facebook.CSSLayout">
       <HintPath>..\References\Facebook.CSSLayout.dll</HintPath>


### PR DESCRIPTION
When we have a use case for these events, we can wire them up further.

During implementation, also discovered that the ReactBridge should also flush the JS queue immediately after loading the bundle. Currently, the WebSockets module is activated for debugging purposes immediately after loading the bundle.