### PR TITLE
Fixes #191 - Change JSON marshaling to use parse and stringify

### DIFF
--- a/ReactWindows/ReactNative/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -14,6 +14,9 @@ namespace ReactNative.Chakra.Executor
     /// </summary>
     public class ChakraJavaScriptExecutor : IJavaScriptExecutor
     {
+        private static readonly JToken s_null = JValue.CreateNull();
+        private static readonly JToken s_undefined = JValue.CreateUndefined();
+
         private readonly JavaScriptRuntime _runtime;
         private readonly JavaScriptValue _globalObject;
 
@@ -250,6 +253,14 @@ namespace ReactNative.Chakra.Executor
 #else
         private JavaScriptValue ConvertJson(JToken token)
         {
+            switch (token.Type)
+            {
+                case JTokenType.Null:
+                    return JavaScriptValue.Null;
+                case JTokenType.Undefined:
+                    return JavaScriptValue.Undefined;
+            }
+
             var jsonHelpers = _globalObject.GetProperty(JavaScriptPropertyId.FromString("JSON"));
             var parseFunction = jsonHelpers.GetProperty(JavaScriptPropertyId.FromString("parse"));
 
@@ -261,6 +272,14 @@ namespace ReactNative.Chakra.Executor
 
         private JToken ConvertJson(JavaScriptValue value)
         {
+            switch (value.ValueType)
+            {
+                case JavaScriptValueType.Undefined:
+                    return s_undefined;
+                case JavaScriptValueType.Null:
+                    return s_null;
+            }
+
             var jsonHelpers = _globalObject.GetProperty(JavaScriptPropertyId.FromString("JSON"));
             var stringifyFunction = jsonHelpers.GetProperty(JavaScriptPropertyId.FromString("stringify"));
 

--- a/ReactWindows/ReactNative/Chakra/Executor/JTokenToJavaScriptValueConverter.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/JTokenToJavaScriptValueConverter.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿#if NATIVE_JSON_MARSHALING
+using Newtonsoft.Json.Linq;
 using System;
 
 namespace ReactNative.Chakra.Executor
@@ -115,3 +116,4 @@ namespace ReactNative.Chakra.Executor
         }
     }
 }
+#endif

--- a/ReactWindows/ReactNative/Chakra/Executor/JavaScriptValueToJTokenConverter.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/JavaScriptValueToJTokenConverter.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿#if NATIVE_JSON_MARSHALING
+using Newtonsoft.Json.Linq;
 using System;
 
 namespace ReactNative.Chakra.Executor
@@ -104,3 +105,4 @@ namespace ReactNative.Chakra.Executor
         }
     }
 }
+#endif


### PR DESCRIPTION
After running throughput performance experiments, it was discovered that it's actually faster to marshal JSON data by first stringifying in C#, sending as a string value to Chakra, and then parsing in Chakra (and the inverse applies coming from Chakra to C#).

This changeset swaps out the visitor pattern for generating Chakra JavaScript values for the serialize / parse method.