### PR TITLE
Towards #143 - Replaces ListView with ScrollViewer for ReactScrollViewManager

### DIFF
--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -264,6 +264,10 @@
     <Compile Include="Views\Image\ReactImageLoadEvent.cs" />
     <Compile Include="Views\Image\ReactImageManager.cs" />
     <Compile Include="Views\Image\ReactVirtualImageManager.cs" />
+    <Compile Include="Views\Scroll\IScrollCommandHandler.cs" />
+    <Compile Include="Views\Scroll\ReactScrollViewCommandHelper.cs" />
+    <Compile Include="Views\Scroll\ScrollEventType.cs" />
+    <Compile Include="Views\Scroll\ScrollEventTypeExtensions.cs" />
     <Compile Include="Views\TextInput\ReactMultilineTextInputManager.cs" />
     <Compile Include="Views\TextInput\TextBoxExtensions.cs" />
     <Compile Include="Views\Text\FontStyleHelpers.cs" />

--- a/ReactWindows/ReactNative/UIManager/ViewManager.cs
+++ b/ReactWindows/ReactNative/UIManager/ViewManager.cs
@@ -149,9 +149,9 @@ namespace ReactNative.UIManager
 
         /// <summary>
         /// Implement this method to receive events/commands directly from
-        /// JavaScript through the <see cref="UIManager"/>.
+        /// JavaScript through the <see cref="UIManagerModule"/>.
         /// </summary>
-        /// <param name="root">
+        /// <param name="view">
         /// The view instance that should receive the command.
         /// </param>
         /// <param name="commandId">Identifer for the command.</param>

--- a/ReactWindows/ReactNative/Views/Scroll/IScrollCommandHandler.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/IScrollCommandHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace ReactNative.Views.Scroll
+{
+    interface IScrollCommandHandler<T>
+    {
+        void ScrollTo(T scrollView, double x, double y, bool animated);
+    }
+}

--- a/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewCommandHelper.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewCommandHelper.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+
+namespace ReactNative.Views.Scroll
+{
+    static class ReactScrollViewCommandHelper
+    {
+        private const int CommandScrollTo = 1;
+
+        public static IDictionary<string, object> CommandsMap
+        {
+            get
+            {
+                return new Dictionary<string, object>
+                {
+                    { "scrollTo", CommandScrollTo },
+                };
+            }
+        }
+
+        public static void ReceiveCommand<T>(IScrollCommandHandler<T> viewManager, T scrollView, int commandId, JArray args)
+        {
+            if (viewManager == null)
+                throw new ArgumentNullException(nameof(viewManager));
+            if (scrollView == null)
+                throw new ArgumentNullException(nameof(scrollView));
+            if (args == null)
+                throw new ArgumentNullException(nameof(args));
+
+            switch (commandId)
+            {
+                case CommandScrollTo:
+                    var x = args[0].Value<double>();
+                    var y = args[1].Value<double>();
+                    var animated = args[2].Value<bool>();
+                    viewManager.ScrollTo(scrollView, x, y, animated);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unsupported command '{commandId}' received by '{viewManager.GetType()}'.");
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
@@ -1,55 +1,272 @@
-﻿using ReactNative.UIManager;
+﻿using Newtonsoft.Json.Linq;
+using ReactNative.UIManager;
+using ReactNative.UIManager.Events;
+using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace ReactNative.Views.Scroll
 {
     /// <summary>
-    /// A hacked in version of the scroll view manager.
+    /// The view manager for scrolling views.
     /// </summary>
-    /// <remarks>
-    /// TODO: implement this as a proper ScrollViewer instead of a ListView.
-    /// </remarks>
-    public class ReactScrollViewManager : ViewParentManager<ListView>
+    public class ReactScrollViewManager : ViewParentManager<ScrollViewer>, IScrollCommandHandler<ScrollViewer>
     {
-        private const string ReactClass = "RCTScrollView";
-
+        /// <summary>
+        /// The name of the view manager.
+        /// </summary>
         public override string Name
         {
             get
             {
-                return ReactClass;
+                return "RCTScrollView";
             }
         }
 
-        public override void AddView(ListView parent, FrameworkElement child, int index)
+        /// <summary>
+        /// Sets whether scroll is enabled on the view.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="enabled">The enabled value.</param>
+        [ReactProperty("scrollEnabled", DefaultBoolean = true)]
+        public void SetEnabled(ScrollViewer view, bool enabled)
         {
-            parent.Items.Insert(index, child);
+            view.IsEnabled = enabled;
         }
 
-        public override FrameworkElement GetChildAt(ListView parent, int index)
+        /// <summary>
+        /// Adds a child at the given index.
+        /// </summary>
+        /// <param name="parent">The parent view.</param>
+        /// <param name="child">The child view.</param>
+        /// <param name="index">The index.</param>
+        /// <remarks>
+        /// <see cref="ReactScrollViewManager"/> only supports one child.
+        /// </remarks>
+        public override void AddView(ScrollViewer parent, FrameworkElement child, int index)
         {
-            return (FrameworkElement)parent.Items[index];
+            if (index != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), "ScrollViewer currently only supports one child.");
+            }
+
+            if (parent.Content != null)
+            {
+                throw new InvalidOperationException("ScrollViewer already has a child element.");
+            }
+
+            parent.Content = child;
         }
 
-        public override int GetChildCount(ListView parent)
+        /// <summary>
+        /// Gets the child at the given index.
+        /// </summary>
+        /// <param name="parent">The parent view.</param>
+        /// <param name="index">The index.</param>
+        /// <returns>The child view.</returns>
+        /// <remarks>
+        /// <see cref="ReactScrollViewManager"/> only supports one child.
+        /// </remarks>
+        public override FrameworkElement GetChildAt(ScrollViewer parent, int index)
         {
-            return parent.Items.Count;
+            if (index != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), "ScrollView currently only supports one child.");
+            }
+
+            return EnsureChild(parent);
         }
 
-        public override void RemoveAllChildren(ListView parent)
+        /// <summary>
+        /// Gets the number of children in the view parent.
+        /// </summary>
+        /// <param name="parent">The view parent.</param>
+        /// <returns>The number of children.</returns>
+        public override int GetChildCount(ScrollViewer parent)
         {
-            parent.Items.Clear();
+            return parent.Content != null ? 1 : 0;
         }
 
-        public override void RemoveChildAt(ListView parent, int index)
+        /// <summary>
+        /// Removes all children from the view parent.
+        /// </summary>
+        /// <param name="parent">The view parent.</param>
+        public override void RemoveAllChildren(ScrollViewer parent)
         {
-            parent.Items.RemoveAt(index);
+            RemoveChildAt(parent, 0);
         }
 
-        protected override ListView CreateViewInstance(ThemedReactContext reactContext)
+        /// <summary>
+        /// Removes the child at the given index.
+        /// </summary>
+        /// <param name="parent">The view parent.</param>
+        /// <param name="index">The index.</param>
+        /// <remarks>
+        /// <see cref="ReactScrollViewManager"/> only supports one child.
+        /// </remarks>
+        public override void RemoveChildAt(ScrollViewer parent, int index)
         {
-            return new ListView();
+            if (index != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), "ScrollView currently only supports one child.");
+            }
+
+            EnsureChild(parent);
+            parent.Content = null;
+        }
+
+        /// <summary>
+        /// Creates a new view instance.
+        /// </summary>
+        /// <param name="reactContext">The react context.</param>
+        /// <returns>The view instance.</returns>
+        protected override ScrollViewer CreateViewInstance(ThemedReactContext reactContext)
+        {
+            var view = new ScrollViewer();
+            view.ViewChanging += OnViewChanging;
+            return view;
+        }
+
+        /// <summary>
+        /// Called when view is detached from view hierarchy and allows for 
+        /// additional cleanup by the <see cref="ViewManager"/>
+        /// subclass.
+        /// </summary>
+        /// <param name="reactContext">The react context.</param>
+        /// <param name="view">The view.</param>
+        public override void OnDropViewInstance(ThemedReactContext reactContext, ScrollViewer view)
+        {
+            view.ViewChanging -= OnViewChanging;
+        }
+
+        /// <summary>
+        /// Receive events/commands directly from JavaScript through the 
+        /// <see cref="UIManagerModule"/>.
+        /// </summary>
+        /// <param name="root">
+        /// The view instance that should receive the command.
+        /// </param>
+        /// <param name="commandId">Identifer for the command.</param>
+        /// <param name="args">Optional arguments for the command.</param>
+        public override void ReceiveCommand(ScrollViewer view, int commandId, JArray args)
+        {
+            ReactScrollViewCommandHelper.ReceiveCommand(this, view, commandId, args);
+        }
+
+        /// <summary>
+        /// Scroll to a specific offset.
+        /// </summary>
+        /// <param name="scrollView">The scroll view.</param>
+        /// <param name="x">The X-coordinate.</param>
+        /// <param name="y">The Y-coordinate.</param>
+        /// <param name="animated">
+        /// <code>true</code> if the scroll should be animated, <code>false</code> otherwise.
+        /// </param>
+        public void ScrollTo(ScrollViewer scrollView, double x, double y, bool animated)
+        {
+            if (animated)
+            {
+                throw new NotImplementedException("Animated scroll has not yet been implemented.");
+            }
+
+            scrollView.ScrollToHorizontalOffset(x);
+            scrollView.ScrollToVerticalOffset(y);
+        }
+
+        private void OnViewChanging(object sender, ScrollViewerViewChangingEventArgs args)
+        {
+            var nextView = args.NextView;
+            var scrollViewer = (ScrollViewer)sender;
+            var reactTag = scrollViewer.GetTag();
+
+            // Scroll position
+            var contentOffset = new JObject
+            {
+                { "x", nextView.HorizontalOffset },
+                { "y", nextView.VerticalOffset },
+            };
+
+            // Distance the content view is inset from the enclosing scroll view
+            // TODO: Should these always be 0 for the XAML ScrollViewer?
+            var contentInset = new JObject
+            {
+                { "top", 0 },
+                { "bottom", 0 },
+                { "left", 0 },
+                { "right", 0 },
+            };
+
+            // Size of the content view
+            var contentSize = new JObject
+            {
+                { "width", scrollViewer.ExtentWidth },
+                { "height", scrollViewer.ExtentHeight },
+            };
+
+            // Size of the viewport
+            var layoutMeasurement = new JObject
+            {
+                { "width", scrollViewer.ActualWidth },
+                { "height", scrollViewer.ActualHeight },
+            };
+
+            var scrollEvent = new ScrollEvent(reactTag, ScrollEventType.Scroll, new JObject
+            {
+                { "target", reactTag },
+                { "contentOffset", contentOffset },
+                { "contentInset", contentInset },
+                { "contentSize", contentSize },
+                { "layoutMeasurement", layoutMeasurement },
+                { "zoomScale", nextView.ZoomFactor },
+            });
+
+            scrollViewer.GetReactContext()
+                .GetNativeModule<UIManagerModule>()
+                .EventDispatcher
+                .DispatchEvent(scrollEvent);
+        }
+
+        private static FrameworkElement EnsureChild(ScrollViewer view)
+        {
+            var child = view.Content;
+            if (child == null)
+            {
+                throw new InvalidOperationException("ScrollView does not have any children.");
+            }
+
+            var frameworkElement = child as FrameworkElement;
+            if (frameworkElement == null)
+            {
+                throw new InvalidOperationException("Invalid child element in ScrollView.");
+            }
+
+            return frameworkElement;
+        }
+
+        class ScrollEvent : Event
+        {
+            private readonly ScrollEventType _type;
+            private readonly JObject _data;
+
+            public ScrollEvent(int viewTag, ScrollEventType type, JObject data)
+                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            {
+                _type = type;
+                _data = data;
+            }
+
+            public override string EventName
+            {
+                get
+                {
+                    return _type.GetJavaScriptEventName();
+                }
+            }
+
+            public override void Dispatch(RCTEventEmitter eventEmitter)
+            {
+                eventEmitter.receiveEvent(ViewTag, EventName, _data);
+            }
         }
     }
 }

--- a/ReactWindows/ReactNative/Views/Scroll/ScrollEventType.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ScrollEventType.cs
@@ -1,0 +1,13 @@
+﻿namespace ReactNative.Views.Scroll
+{
+    /// <summary>
+    /// Scroll event types.
+    /// </summary>
+    public enum ScrollEventType
+    {
+        /// <summary>
+        /// The scroll event.
+        /// </summary>
+        Scroll,
+    }
+}

--- a/ReactWindows/ReactNative/Views/Scroll/ScrollEventTypeExtensions.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ScrollEventTypeExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace ReactNative.Views.Scroll
+{
+    static class ScrollEventTypeExtensions
+    {
+        public static string GetJavaScriptEventName(this ScrollEventType type)
+        {
+            switch (type)
+            {
+                case ScrollEventType.Scroll:
+                    return "topScroll";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), $"Unknown scroll event type '{type}'.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
ScrollView is obviously important for making lists work on RN for UWP.

There's still work to be done around momentum events, horizontal scroll, etc., but this should provide a solid base.