### PR TITLE
Fixes #224 - ExecutionEngineException no longer occurs

### DIFF
--- a/ReactWindows/ReactNative/Chakra/Executor/ChakraJavaScriptExecutor.cs
+++ b/ReactWindows/ReactNative/Chakra/Executor/ChakraJavaScriptExecutor.cs
@@ -16,6 +16,10 @@ namespace ReactNative.Chakra.Executor
     {
         private readonly JavaScriptRuntime _runtime;
 
+        private JavaScriptNativeFunction _consoleLog;
+        private JavaScriptNativeFunction _consoleWarn;
+        private JavaScriptNativeFunction _consoleError;
+
         private JavaScriptValue _globalObject;
         private JavaScriptValue _requireFunction;
 
@@ -155,9 +159,13 @@ namespace ReactNative.Chakra.Executor
             var consoleObject = JavaScriptValue.CreateObject();
             EnsureGlobalObject().SetProperty(consolePropertyId, consoleObject, true);
 
-            DefineHostCallback(consoleObject, "log", ConsoleLog, IntPtr.Zero);
-            DefineHostCallback(consoleObject, "warn", ConsoleWarn, IntPtr.Zero);
-            DefineHostCallback(consoleObject, "error", ConsoleError, IntPtr.Zero);
+            _consoleLog = ConsoleLog;
+            _consoleWarn = ConsoleWarn;
+            _consoleError = ConsoleError;
+
+            DefineHostCallback(consoleObject, "log", _consoleLog, IntPtr.Zero);
+            DefineHostCallback(consoleObject, "warn", _consoleWarn, IntPtr.Zero);
+            DefineHostCallback(consoleObject, "error", _consoleError, IntPtr.Zero);
 
             Debug.WriteLine("Chakra initialization successful.");
         }


### PR DESCRIPTION
As it turns out, when you pass a delegate to Chakra to define native functions, make sure you hang on to a reference to that delegate.

The delegates for console.log, console.warn, and console.error were being garbage collected, so when React Native made calls to them, they tried to invoke a delegate that was already garbage collected.

The ChakraJavaScriptExecutor now holds references to these for the entire lifetime of the object.