### PR TITLE
Fixes #178 - Part 1: ReactWindows folder changes to support windows platform in the bundler

### DIFF
--- a/ReactWindows/Playground/AppReactPage.cs
+++ b/ReactWindows/Playground/AppReactPage.cs
@@ -19,7 +19,7 @@ namespace Playground
         {
             get
             {
-                return "ReactWindows/Playground/index.ios";
+                return "ReactWindows/Playground/index.windows";
             }
         }
 

--- a/ReactWindows/Playground/index.windows.js
+++ b/ReactWindows/Playground/index.windows.js
@@ -1,0 +1,139 @@
+'use strict';
+import React, {
+    AppRegistry,
+    Component,
+    StyleSheet,
+    Text,
+    View,
+    TouchableOpacity,
+    LayoutAnimation,
+} from 'react-native';
+
+var CustomLayoutAnimation = {
+    duration: 200,
+    create: {
+        type: LayoutAnimation.Types.linear,
+        property: LayoutAnimation.Properties.opacity,
+        delay: 200,
+    },
+    update: {
+        type: LayoutAnimation.Types.easeInEaseOut,
+    },
+};
+
+class AnimationExample extends Component {
+
+    constructor() {
+        super();
+
+        this.state = {
+            index: 0,
+        }
+    }
+
+    onPress(index) {
+
+        // Uncomment to animate the next state change.
+        //LayoutAnimation.configureNext(LayoutAnimation.Presets.spring);
+
+        // Or use a Custom Layout Animation
+        LayoutAnimation.configureNext(CustomLayoutAnimation);
+
+        this.setState({index: index});
+    }
+
+    renderButton(index) {
+        return (
+          <TouchableOpacity key={'button' + index} style={styles.button} onPress={() => this.onPress(index)}>
+            <Text>{index}</Text>
+          </TouchableOpacity>
+        );
+            }
+
+    renderCircle(key) {
+        var size = 50;
+        return (
+          <View key={key} style={{width: size, height: size, borderRadius: size / 2.0, backgroundColor: 'sandybrown', margin: 20}}/>
+        );
+}
+
+render() {
+
+    var leftStyle = this.state.index === 0 ? {flex: 1} : {width: 20};
+    var middleStyle = this.state.index === 2 ? {width: 20} : {flex: 1};
+    var rightStyle = {flex: 1};
+
+    var whiteHeight = this.state.index * 80;
+
+    var circles = [];
+    for (var i = 0; i < (5 + this.state.index); i++) {
+        circles.push(this.renderCircle(i));
+    }
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.topButtons}>
+          {this.renderButton(0)}
+{this.renderButton(1)}
+{this.renderButton(2)}
+</View>
+<View style={styles.content}>
+  <View style={{flexDirection: 'row', height: 100}}>
+            <View style={[leftStyle, {backgroundColor: 'firebrick'}]}/>
+            <View style={[middleStyle, {backgroundColor: 'seagreen'}]}/>
+            <View style={[rightStyle, {backgroundColor: 'steelblue'}]}/>
+          </View>
+          <View style={{height: whiteHeight, justifyContent: 'center', alignItems: 'center', overflow: 'hidden'}}>
+            <View>
+              <Text>Stuff Goes Here</Text>
+            </View>
+          </View>
+          <View style={styles.circleContainer}>
+            {circles}
+          </View>
+        </View>
+      </View>
+    );
+}
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#F5FCFF',
+    },
+    topButtons: {
+        marginTop: 22,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        alignSelf: 'stretch',
+        backgroundColor: 'lightblue',
+    },
+    button: {
+        flex: 1,
+        height: 60,
+        alignSelf: 'stretch',
+        backgroundColor: 'white',
+        alignItems: 'center',
+        justifyContent: 'center',
+        margin: 8,
+    },
+    content: {
+        flex: 1,
+        alignSelf: 'stretch',
+    },
+    circleContainer: {
+        flexDirection: 'row',
+        flex: 1,
+        flexWrap: 'wrap',
+        padding: 30,
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
+});
+
+AppRegistry.registerComponent('ReactRoot', () => AnimationExample);
+

--- a/ReactWindows/ReactNative/DevSupport/DevServerHelper.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevServerHelper.cs
@@ -19,8 +19,8 @@ namespace ReactNative.DevSupport
     class DevServerHelper
     {
         private const string DeviceLocalhost = "localhost:8081";
-        private const string BundleUrlFormat = "http://{0}/{1}.bundle?platform=ios&dev={2}&hot={3}";
-        private const string SourceMapUrlFormat = "http://{0}/{1}.map?platform=ios&dev={2}&hot={3}";
+        private const string BundleUrlFormat = "http://{0}/{1}.bundle?platform=windows&dev={2}&hot={3}";
+        private const string SourceMapUrlFormat = "http://{0}/{1}.map?platform=windows&dev={2}&hot={3}";
         private const string LaunchDevToolsCommandUrlFormat = "http://{0}/launch-chrome-devtools";
         private const string OnChangeEndpointUrlFormat = "http://{0}/onchange";
         private const string WebsocketProxyUrlFormat = "ws://{0}/debugger-proxy?role=client";

--- a/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
@@ -30,7 +30,7 @@ namespace ReactNative.DevSupport
 
         private bool _isDevSupportEnabled = true;
         private bool _isShakeDetectorRegistered;
-        private bool _isUsingJsProxy;
+        private bool _isUsingJsProxy = true;
 
         private RedBoxDialog _redBoxDialog;
         private Action _dismissRedBoxDialog;

--- a/ReactWindows/ReactNative/ReactPage.cs
+++ b/ReactWindows/ReactNative/ReactPage.cs
@@ -56,7 +56,7 @@ namespace ReactNative
         {
             get
             {
-                return "index.ios";
+                return "index.windows";
             }
         }
 

--- a/ReactWindows/js/Image/Image.windows.js
+++ b/ReactWindows/js/Image/Image.windows.js
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule Image
+ * @flow
+ */
+'use strict';
+
+var EdgeInsetsPropType = require('EdgeInsetsPropType');
+var ImageResizeMode = require('ImageResizeMode');
+var ImageStylePropTypes = require('ImageStylePropTypes');
+var NativeMethodsMixin = require('NativeMethodsMixin');
+var PropTypes = require('ReactPropTypes');
+var React = require('React');
+var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
+var View = require('View');
+var StyleSheet = require('StyleSheet');
+var StyleSheetPropType = require('StyleSheetPropType');
+
+var flattenStyle = require('flattenStyle');
+var invariant = require('fbjs/lib/invariant');
+var requireNativeComponent = require('requireNativeComponent');
+var resolveAssetSource = require('resolveAssetSource');
+var warning = require('fbjs/lib/warning');
+
+var {
+  ImageViewManager,
+  NetworkImageViewManager,
+} = require('NativeModules');
+
+/**
+ * A React component for displaying different types of images,
+ * including network images, static resources, temporary local images, and
+ * images from local disk, such as the camera roll.
+ *
+ * Example usage:
+ *
+ * ```
+ * renderImages: function() {
+ *   return (
+ *     <View>
+ *       <Image
+ *         style={styles.icon}
+ *         source={require('./myIcon.png')}
+ *       />
+ *       <Image
+ *         style={styles.logo}
+ *         source={{uri: 'http://facebook.github.io/react/img/logo_og.png'}}
+ *       />
+ *     </View>
+ *   );
+ * },
+ * ```
+ */
+var Image = React.createClass({
+  propTypes: {
+    style: StyleSheetPropType(ImageStylePropTypes),
+    /**
+     * `uri` is a string representing the resource identifier for the image, which
+     * could be an http address, a local file path, or the name of a static image
+     * resource (which should be wrapped in the `require('./path/to/image.png')` function).
+     */
+    source: PropTypes.oneOfType([
+      PropTypes.shape({
+        uri: PropTypes.string,
+      }),
+      // Opaque type returned by require('./image.jpg')
+      PropTypes.number,
+    ]),
+    /**
+     * A static image to display while loading the image source.
+     * @platform windows
+     */
+    defaultSource: PropTypes.oneOfType([
+      PropTypes.shape({
+        uri: PropTypes.string,
+      }),
+      // Opaque type returned by require('./image.jpg')
+      PropTypes.number,
+    ]),
+    /**
+     * When true, indicates the image is an accessibility element.
+     * @platform windows
+     */
+    accessible: PropTypes.bool,
+    /**
+     * The text that's read by the screen reader when the user interacts with
+     * the image.
+     * @platform windows
+     */
+    accessibilityLabel: PropTypes.string,
+    /**
+     * Determines how to resize the image when the frame doesn't match the raw
+     * image dimensions.
+     *
+     * 'cover': Scale the image uniformly (maintain the image's aspect ratio)
+     * so that both dimensions (width and height) of the image will be equal
+     * to or larger than the corresponding dimension of the view (minus padding).
+     *
+     * 'contain': Scale the image uniformly (maintain the image's aspect ratio)
+     * so that both dimensions (width and height) of the image will be equal to
+     * or less than the corresponding dimension of the view (minus padding).
+     *
+     * 'stretch': Scale width and height independently, This may change the
+     * aspect ratio of the src.
+     */
+    resizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch']),
+    /**
+     * A unique identifier for this element to be used in UI Automation
+     * testing scripts.
+     */
+    testID: PropTypes.string,
+    /**
+     * Invoked on mount and layout changes with
+     * `{nativeEvent: {layout: {x, y, width, height}}}`.
+     */
+    onLayout: PropTypes.func,
+    /**
+     * Invoked on load start
+     */
+    onLoadStart: PropTypes.func,
+    /**
+     * Invoked on download progress with `{nativeEvent: {loaded, total}}`
+     * @platform windows
+     */
+    onProgress: PropTypes.func,
+    /**
+     * Invoked on load error with `{nativeEvent: {error}}`
+     * @platform windows
+     */
+    onError: PropTypes.func,
+    /**
+     * Invoked when load completes successfully
+     */
+    onLoad: PropTypes.func,
+    /**
+     * Invoked when load either succeeds or fails
+     */
+    onLoadEnd: PropTypes.func,
+  },
+
+  statics: {
+    resizeMode: ImageResizeMode,
+    /**
+     * Retrieve the width and height (in pixels) of an image prior to displaying it.
+     * This method can fail if the image cannot be found, or fails to download.
+     *
+     * In order to retrieve the image dimensions, the image may first need to be
+     * loaded or downloaded, after which it will be cached. This means that in
+     * principle you could use this method to preload images, however it is not
+     * optimized for that purpose, and may in future be implemented in a way that
+     * does not fully load/download the image data. A proper, supported way to
+     * preload images will be provided as a separate API.
+     *
+     * @platform windows
+     */
+    getSize: function(
+      uri: string,
+      success: (width: number, height: number) => void,
+      failure: (error: any) => void,
+    ) {
+      ImageViewManager.getSize(uri, success, failure || function() {
+        console.warn('Failed to get size for image: ' + uri);
+      });
+    }
+  },
+
+  mixins: [NativeMethodsMixin],
+
+  /**
+   * `NativeMethodsMixin` will look for this when invoking `setNativeProps`. We
+   * make `this` look like an actual native component class.
+   */
+  viewConfig: {
+    uiViewClassName: 'UIView',
+    validAttributes: ReactNativeViewAttributes.UIView
+  },
+
+  contextTypes: {
+    isInAParentText: React.PropTypes.bool
+  },
+
+  render: function() {
+    var source = resolveAssetSource(this.props.source) || {};
+    var {width, height, uri} = source;
+    var style = flattenStyle([{width, height}, styles.base, this.props.style]) || {};
+
+    var isNetwork = uri && uri.match(/^https?:/);
+    var RawImage = isNetwork ? RCTNetworkImageView : RCTImageView;
+    var resizeMode = this.props.resizeMode || (style || {}).resizeMode || 'cover'; // Workaround for flow bug t7737108
+    var tintColor = (style || {}).tintColor; // Workaround for flow bug t7737108
+
+    // This is a workaround for #8243665. RCTNetworkImageView does not support tintColor
+    // TODO: Remove this hack once we have one image implementation #8389274
+    if (isNetwork && tintColor) {
+      RawImage = RCTImageView;
+    }
+
+    if (this.props.src) {
+      console.warn('The <Image> component requires a `source` property rather than `src`.');
+    }
+
+    if (this.context.isInAParentText) {
+      RawImage = RCTVirtualImage;
+      if (!width || !height) {
+        console.warn('You must specify a width and height for the image %s', uri);
+      }
+    }
+
+    return (
+      <RawImage
+        {...this.props}
+        style={style}
+        resizeMode={resizeMode}
+        tintColor={tintColor}
+        source={source}
+      />
+    );
+  },
+});
+
+var styles = StyleSheet.create({
+  base: {
+    overflow: 'hidden',
+  },
+});
+
+var RCTImageView = requireNativeComponent('RCTImageView', Image);
+var RCTNetworkImageView = NetworkImageViewManager ? requireNativeComponent('RCTNetworkImageView', Image) : RCTImageView;
+var RCTVirtualImage = requireNativeComponent('RCTVirtualImage', Image);
+
+
+module.exports = Image;
+

--- a/ReactWindows/js/Network/RCTNetworking.windows.js
+++ b/ReactWindows/js/Network/RCTNetworking.windows.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016-present, Microsoft, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule RCTNetworking
+ */
+'use strict';
+
+// Do not require the native RCTNetworking module directly! Use this wrapper module instead.
+// It will add the necessary requestId, so that you don't have to generate it yourself.
+var RCTNetworkingNative = require('NativeModules').Networking;
+
+var _requestId = 1;
+var generateRequestId = function() {
+  return _requestId++;
+};
+
+/**
+ * This class is a wrapper around the native RCTNetworking module. It adds a necessary unique
+ * requestId to each network request that can be used to abort that request later on.
+ */
+class RCTNetworking {
+
+  static sendRequest(method, url, headers, data, useIncrementalUpdates, timeout) {
+    var requestId = generateRequestId();
+    RCTNetworkingNative.sendRequest(
+      method,
+      url,
+      requestId,
+      headers,
+      data,
+      useIncrementalUpdates,
+      timeout);
+    return requestId;
+  }
+
+  static abortRequest(requestId) {
+    RCTNetworkingNative.abortRequest(requestId);
+  }
+
+}
+
+module.exports = RCTNetworking;
+

--- a/ReactWindows/js/Network/XMLHttpRequest.windows.js
+++ b/ReactWindows/js/Network/XMLHttpRequest.windows.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016-present, Microsoft, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule XMLHttpRequest
+ * @flow
+ */
+'use strict';
+
+var FormData = require('FormData');
+var RCTNetworking = require('RCTNetworking');
+var XMLHttpRequestBase = require('XMLHttpRequestBase');
+
+type Header = [string, string];
+
+function convertHeadersMapToArray(headers: Object): Array<Header> {
+  var headerArray = [];
+  for (var name in headers) {
+    headerArray.push([name, headers[name]]);
+  }
+  return headerArray;
+}
+
+class XMLHttpRequest extends XMLHttpRequestBase {
+  sendImpl(method: ?string, url: ?string, headers: Object, data: any, timeout: number): void {
+    var body;
+    if (typeof data === 'string') {
+      body = {string: data};
+    } else if (data instanceof FormData) {
+      body = {
+        formData: data.getParts().map((part) => {
+          part.headers = convertHeadersMapToArray(part.headers);
+          return part;
+        }),
+      };
+    } else {
+      body = data;
+    }
+    var useIncrementalUpdates = this.onreadystatechange ? true : false;
+    var requestId = RCTNetworking.sendRequest(
+      method,
+      url,
+      convertHeadersMapToArray(headers),
+      body,
+      useIncrementalUpdates,
+      timeout
+    );
+    this.didCreateRequest(requestId);
+  }
+}
+
+module.exports = XMLHttpRequest;
+

--- a/ReactWindows/js/React/renderApplication.windows.js
+++ b/ReactWindows/js/React/renderApplication.windows.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule renderApplication
+ * @noflow
+ */
+
+'use strict';
+
+var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+var React = require('React');
+var StyleSheet = require('StyleSheet');
+var Subscribable = require('Subscribable');
+var View = require('View');
+
+var invariant = require('fbjs/lib/invariant');
+
+var Inspector = __DEV__ ? require('Inspector') : null;
+var YellowBox = __DEV__ ? require('YellowBox') : null;
+
+var AppContainer = React.createClass({
+  mixins: [Subscribable.Mixin],
+
+  getInitialState: function() {
+    return { inspector: null };
+  },
+
+  toggleElementInspector: function() {
+    var inspector = !__DEV__ || this.state.inspector
+      ? null
+      : <Inspector
+          rootTag={this.props.rootTag}
+          inspectedViewTag={React.findNodeHandle(this.refs.main)}
+        />;
+    this.setState({inspector});
+  },
+
+  componentDidMount: function() {
+    this.addListenerOn(
+      RCTDeviceEventEmitter,
+      'toggleElementInspector',
+      this.toggleElementInspector
+    );
+  },
+
+  render: function() {
+    let yellowBox = null;
+    if (__DEV__) {
+      yellowBox = <YellowBox />;
+    }
+    return (
+      <View style={styles.appContainer}>
+        <View collapsible={false} style={styles.appContainer} ref="main">
+          {this.props.children}
+        </View>
+        {yellowBox}
+        {this.state.inspector}
+      </View>
+    );
+  }
+});
+
+function renderApplication<D, P, S>(
+  RootComponent: ReactClass<P>,
+  initialProps: P,
+  rootTag: any
+) {
+  invariant(
+    rootTag,
+    'Expect to have a valid rootTag, instead got ', rootTag
+  );
+  /* eslint-disable jsx-no-undef-with-namespace */
+  React.render(
+    <AppContainer rootTag={rootTag}>
+      <RootComponent
+        {...initialProps}
+        rootTag={rootTag}
+      />
+    </AppContainer>,
+    rootTag
+  );
+  /* eslint-enable jsx-no-undef-with-namespace */
+}
+
+var styles = StyleSheet.create({
+  appContainer: {
+    flex: 1,
+  },
+});
+
+module.exports = renderApplication;
+

--- a/ReactWindows/js/Utilities/Platform.windows.js
+++ b/ReactWindows/js/Utilities/Platform.windows.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule Platform
+ * @flow
+ */
+
+'use strict';
+
+var Platform = {
+  OS: 'windows',
+};
+
+module.exports = Platform;


### PR DESCRIPTION
A key to allowing ReactNative for UWP to differentiate itself is to allow JavaScript customization for native modules and view managers.

This lays the ground work for that, adding the Windows-specific JavaScript exports that are referenced in the core ReactNative modules, and making the necessary changes to ReactPage and the dev support tools.