### PR TITLE
fix(DevSupport): Display JavaScript source code info in red box

### DIFF
--- a/ReactWindows/ReactNative/DevSupport/DevServerHelper.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevServerHelper.cs
@@ -223,8 +223,8 @@ namespace ReactNative.DevSupport
                 SourceMapUrlFormat,
                 DebugServerHost,
                 mainModuleName,
-                IsJavaScriptDevModeEnabled,
-                IsHotModuleReplacementEnabled);
+                IsJavaScriptDevModeEnabled ? "true" : "false",
+                IsHotModuleReplacementEnabled ? "true" : "false");
         }
 
         /// <summary>
@@ -239,8 +239,8 @@ namespace ReactNative.DevSupport
                 BundleUrlFormat,
                 DebugServerHost,
                 mainModuleName,
-                IsJavaScriptDevModeEnabled,
-                IsHotModuleReplacementEnabled);
+                IsJavaScriptDevModeEnabled ? "true" : "false",
+                IsHotModuleReplacementEnabled ? "true" : "false");
         }
 
         /// <summary>
@@ -255,8 +255,8 @@ namespace ReactNative.DevSupport
                 BundleUrlFormat,
                 JavaScriptProxyHost,
                 mainModuleName,
-                IsJavaScriptDevModeEnabled,
-                IsHotModuleReplacementEnabled);
+                IsJavaScriptDevModeEnabled ? "true" : "false",
+                IsHotModuleReplacementEnabled ? "true" : "false");
         }
 
         private string CreatePackagerStatusUrl(string host)

--- a/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
+++ b/ReactWindows/ReactNative/DevSupport/DevSupportManager.cs
@@ -249,7 +249,7 @@ namespace ReactNative.DevSupport
             ShowNewError(message, StackTraceHelper.ConvertNativeStackTrace(exception), NativeErrorCookie);
         }
 
-        public void UpdateJavaScriptError(string title, JArray details, int errorCookie)
+        public void UpdateJavaScriptError(string message, JArray details, int errorCookie)
         {
             DispatcherHelpers.RunOnDispatcher(() =>
             {
@@ -260,7 +260,7 @@ namespace ReactNative.DevSupport
                     return;
                 }
 
-                _redBoxDialog.Title = title;
+                _redBoxDialog.Message = message;
                 _redBoxDialog.StackTrace = StackTraceHelper.ConvertJavaScriptStackTrace(details);
             });
         }

--- a/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml
+++ b/ReactWindows/ReactNative/DevSupport/RedBoxDialog.xaml
@@ -31,9 +31,9 @@
                    FontWeight="SemiBold"
                    Foreground="White"
                    Padding="0 16 0 16"
-                   Text="{x:Bind Path=Message}"
+                   Text="{x:Bind Path=Message, Mode=OneWay}"
                    TextWrapping="Wrap" />
-        <ListView ItemsSource="{x:Bind Path=StackTrace}"
+        <ListView ItemsSource="{x:Bind Path=StackTrace, Mode=OneWay}"
                   ItemTemplate="{StaticResource StackFrameTemplate}"
                   SelectionMode="None">
             <ListView.ItemContainerStyle>

--- a/ReactWindows/ReactNative/DevSupport/StackTraceHelper.cs
+++ b/ReactWindows/ReactNative/DevSupport/StackTraceHelper.cs
@@ -135,7 +135,7 @@ namespace ReactNative.DevSupport
             {
                 get
                 {
-                    return _map.Value<string>("fileName");
+                    return _map.Value<string>("file");
                 }
             }
 


### PR DESCRIPTION
Fix a bug in the dev support stack prevented the JavaScript source code information from displaying properly.