### PR TITLE
fix(ClipboardModule): ClipboardModule unit tests crash test execution process

### DIFF
--- a/ReactWindows/ReactNative.Tests/Modules/Clipboard/ClipboardModuleTests.cs
+++ b/ReactWindows/ReactNative.Tests/Modules/Clipboard/ClipboardModuleTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
-using ReactNative.Bridge;
 using ReactNative.Modules.Clipboard;
 using System;
 using System.Threading;
@@ -7,7 +6,6 @@ using System.Threading;
 namespace ReactNative.Tests.Modules.Clipboard
 {
     [TestClass]
-    [Ignore]
     public class ClipboardModuleTests
     {
         [TestMethod]

--- a/ReactWindows/ReactNative/Modules/Clipboard/ClipboardModule.cs
+++ b/ReactWindows/ReactNative/Modules/Clipboard/ClipboardModule.cs
@@ -1,5 +1,6 @@
 ﻿using ReactNative.Bridge;
 using System;
+using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
 using DataTransfer = Windows.ApplicationModel.DataTransfer;
 
@@ -94,7 +95,7 @@ namespace ReactNative.Modules.Clipboard
         /// <param name="action">The action.</param>
         private static async void RunOnDispatcher(DispatchedHandler action)
         {
-            await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, action);
+            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, action);
         }
     }
 }


### PR DESCRIPTION
The crash dump exception is HRESULT **0x80070005** - E_ACCESSDENIED

**Clipboard set or get may fail with exception if some other application is holding it.**

If the dispatcher is wrong the exception is  HRESULT **0x80070490**  - Element not found.
For example:
   `CoreApplication.GetCurrentView().Dispatcher.RunAsync(CoreDispatcherPriority.Normal, action);`

I had the try - catch previously also on setString.
