### PR TITLE
feat(UIExplorer): Adding unimplemented views for UWP

### DIFF
--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -360,7 +360,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Facebook.CSSLayout">
-      <HintPath>..\References\Facebook.CSSLayout.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)\..\References\Facebook.CSSLayout.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
+++ b/ReactWindows/ReactNative/Views/Image/ReactImageManager.cs
@@ -15,7 +15,6 @@ namespace ReactNative.Views.Image
     public class ReactImageManager : SimpleViewManager<Border>
     {
         private const string ReactClass = "RCTImageView";
-        private const string PROP_SOURCE = "source";
         private const string PROP_URI = "uri";
 
         private Uri _imageSource;
@@ -52,7 +51,7 @@ namespace ReactNative.Views.Image
         /// </summary>
         /// <param name="view">The image view instance.</param>
         /// <param name="sourceMap">The source map.</param>
-        [ReactProperty(PROP_SOURCE)]
+        [ReactProperty(src)]
         public void SetSource(Border view, Dictionary<string, string> sourceMap)
         {
             var source = default(string);

--- a/ReactWindows/js/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js
+++ b/ReactWindows/js/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DrawerLayoutAndroid
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/ReactWindows/js/Components/StatusBar/StatusBarIOS.windows.js
+++ b/ReactWindows/js/Components/StatusBar/StatusBarIOS.windows.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule StatusBarIOS
+ * @flow
+ */
+'use strict';
+
+module.exports = null;

--- a/ReactWindows/js/Components/ToolbarAndroid/ToolbarAndroid.windows.js
+++ b/ReactWindows/js/Components/ToolbarAndroid/ToolbarAndroid.windows.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ToolbarAndroid
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/ReactWindows/js/Components/ViewPager/ViewPagerAndroid.windows.js
+++ b/ReactWindows/js/Components/ViewPager/ViewPagerAndroid.windows.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ViewPagerAndroid
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/ReactWindows/js/Image/Image.windows.js
+++ b/ReactWindows/js/Image/Image.windows.js
@@ -11,58 +11,62 @@
  */
 'use strict';
 
-var EdgeInsetsPropType = require('EdgeInsetsPropType');
+var NativeMethodsMixin = require('NativeMethodsMixin');
+var NativeModules = require('NativeModules');
 var ImageResizeMode = require('ImageResizeMode');
 var ImageStylePropTypes = require('ImageStylePropTypes');
-var NativeMethodsMixin = require('NativeMethodsMixin');
 var PropTypes = require('ReactPropTypes');
 var React = require('React');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-var View = require('View');
 var StyleSheet = require('StyleSheet');
 var StyleSheetPropType = require('StyleSheetPropType');
+var View = require('View');
 
 var flattenStyle = require('flattenStyle');
-var invariant = require('fbjs/lib/invariant');
+var invariant = require('invariant');
+var merge = require('merge');
 var requireNativeComponent = require('requireNativeComponent');
 var resolveAssetSource = require('resolveAssetSource');
-var warning = require('fbjs/lib/warning');
-
-var {
-  ImageViewManager,
-  NetworkImageViewManager,
-} = require('NativeModules');
 
 /**
- * A React component for displaying different types of images,
+ * <Image> - A react component for displaying different types of images,
  * including network images, static resources, temporary local images, and
- * images from local disk, such as the camera roll.
+ * images from local disk, such as the camera roll.  Example usage:
  *
- * Example usage:
+ *   renderImages: function() {
+ *     return (
+ *       <View>
+ *         <Image
+ *           style={styles.icon}
+ *           source={require('./myIcon.png')}
+ *         />
+ *         <Image
+ *           style={styles.logo}
+ *           source={{uri: 'http://facebook.github.io/react/img/logo_og.png'}}
+ *         />
+ *       </View>
+ *     );
+ *   },
  *
- * ```
- * renderImages: function() {
- *   return (
- *     <View>
- *       <Image
- *         style={styles.icon}
- *         source={require('./myIcon.png')}
- *       />
- *       <Image
- *         style={styles.logo}
- *         source={{uri: 'http://facebook.github.io/react/img/logo_og.png'}}
- *       />
- *     </View>
- *   );
- * },
- * ```
+ * More example code in ImageExample.js
  */
+
+var ImageViewAttributes = merge(ReactNativeViewAttributes.UIView, {
+  src: true,
+  loadingIndicatorSrc: true,
+  resizeMode: true,
+  progressiveRenderingEnabled: true,
+  fadeDuration: true,
+  shouldNotifyLoadEvents: true,
+});
+
 var Image = React.createClass({
   propTypes: {
+    ...View.propTypes,
     style: StyleSheetPropType(ImageStylePropTypes),
-    /**
+   /**
      * `uri` is a string representing the resource identifier for the image, which
-     * could be an http address, a local file path, or the name of a static image
+     * could be an http address, a local file path, or a static image
      * resource (which should be wrapped in the `require('./path/to/image.png')` function).
      */
     source: PropTypes.oneOfType([
@@ -73,67 +77,23 @@ var Image = React.createClass({
       PropTypes.number,
     ]),
     /**
-     * A static image to display while loading the image source.
-     * @platform windows
+     * similarly to `source`, this property represents the resource used to render
+     * the loading indicator for the image, displayed until image is ready to be
+     * displayed, typically after when it got downloaded from network.
      */
-    defaultSource: PropTypes.oneOfType([
+    loadingIndicatorSource: PropTypes.oneOfType([
       PropTypes.shape({
         uri: PropTypes.string,
       }),
       // Opaque type returned by require('./image.jpg')
       PropTypes.number,
     ]),
-    /**
-     * When true, indicates the image is an accessibility element.
-     * @platform windows
-     */
-    accessible: PropTypes.bool,
-    /**
-     * The text that's read by the screen reader when the user interacts with
-     * the image.
-     * @platform windows
-     */
-    accessibilityLabel: PropTypes.string,
-    /**
-     * Determines how to resize the image when the frame doesn't match the raw
-     * image dimensions.
-     *
-     * 'cover': Scale the image uniformly (maintain the image's aspect ratio)
-     * so that both dimensions (width and height) of the image will be equal
-     * to or larger than the corresponding dimension of the view (minus padding).
-     *
-     * 'contain': Scale the image uniformly (maintain the image's aspect ratio)
-     * so that both dimensions (width and height) of the image will be equal to
-     * or less than the corresponding dimension of the view (minus padding).
-     *
-     * 'stretch': Scale width and height independently, This may change the
-     * aspect ratio of the src.
-     */
-    resizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch']),
-    /**
-     * A unique identifier for this element to be used in UI Automation
-     * testing scripts.
-     */
-    testID: PropTypes.string,
-    /**
-     * Invoked on mount and layout changes with
-     * `{nativeEvent: {layout: {x, y, width, height}}}`.
-     */
-    onLayout: PropTypes.func,
+    progressiveRenderingEnabled: PropTypes.bool,
+    fadeDuration: PropTypes.number,
     /**
      * Invoked on load start
      */
     onLoadStart: PropTypes.func,
-    /**
-     * Invoked on download progress with `{nativeEvent: {loaded, total}}`
-     * @platform windows
-     */
-    onProgress: PropTypes.func,
-    /**
-     * Invoked on load error with `{nativeEvent: {error}}`
-     * @platform windows
-     */
-    onError: PropTypes.func,
     /**
      * Invoked when load completes successfully
      */
@@ -142,43 +102,48 @@ var Image = React.createClass({
      * Invoked when load either succeeds or fails
      */
     onLoadEnd: PropTypes.func,
+    /**
+     * Used to locate this view in end-to-end tests.
+     */
+    testID: PropTypes.string,
   },
 
   statics: {
     resizeMode: ImageResizeMode,
-    /**
-     * Retrieve the width and height (in pixels) of an image prior to displaying it.
-     * This method can fail if the image cannot be found, or fails to download.
-     *
-     * In order to retrieve the image dimensions, the image may first need to be
-     * loaded or downloaded, after which it will be cached. This means that in
-     * principle you could use this method to preload images, however it is not
-     * optimized for that purpose, and may in future be implemented in a way that
-     * does not fully load/download the image data. A proper, supported way to
-     * preload images will be provided as a separate API.
-     *
-     * @platform windows
-     */
-    getSize: function(
-      uri: string,
-      success: (width: number, height: number) => void,
-      failure: (error: any) => void,
-    ) {
-      ImageViewManager.getSize(uri, success, failure || function() {
-        console.warn('Failed to get size for image: ' + uri);
-      });
-    }
   },
 
   mixins: [NativeMethodsMixin],
 
   /**
    * `NativeMethodsMixin` will look for this when invoking `setNativeProps`. We
-   * make `this` look like an actual native component class.
+   * make `this` look like an actual native component class. Since it can render
+   * as 3 different native components we need to update viewConfig accordingly
    */
   viewConfig: {
-    uiViewClassName: 'UIView',
-    validAttributes: ReactNativeViewAttributes.UIView
+    uiViewClassName: 'RCTView',
+    validAttributes: ReactNativeViewAttributes.RCTView,
+  },
+
+  _updateViewConfig: function(props) {
+    if (props.children) {
+      this.viewConfig = {
+        uiViewClassName: 'RCTView',
+        validAttributes: ReactNativeViewAttributes.RCTView,
+      };
+    } else {
+      this.viewConfig = {
+        uiViewClassName: 'RCTImageView',
+        validAttributes: ImageViewAttributes,
+      };
+    }
+  },
+
+  componentWillMount: function() {
+    this._updateViewConfig(this.props);
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    this._updateViewConfig(nextProps);
   },
 
   contextTypes: {
@@ -186,54 +151,76 @@ var Image = React.createClass({
   },
 
   render: function() {
-    var source = resolveAssetSource(this.props.source) || {};
-    var {width, height, uri} = source;
-    var style = flattenStyle([{width, height}, styles.base, this.props.style]) || {};
+    var source = resolveAssetSource(this.props.source);
+    var loadingIndicatorSource = resolveAssetSource(this.props.loadingIndicatorSource);
 
-    var isNetwork = uri && uri.match(/^https?:/);
-    var RawImage = isNetwork ? RCTNetworkImageView : RCTImageView;
-    var resizeMode = this.props.resizeMode || (style || {}).resizeMode || 'cover'; // Workaround for flow bug t7737108
-    var tintColor = (style || {}).tintColor; // Workaround for flow bug t7737108
+    // As opposed to the ios version, here it render `null`
+    // when no source or source.uri... so let's not break that.
 
-    // This is a workaround for #8243665. RCTNetworkImageView does not support tintColor
-    // TODO: Remove this hack once we have one image implementation #8389274
-    if (isNetwork && tintColor) {
-      RawImage = RCTImageView;
+    if (source && source.uri === '') {
+      console.warn('source.uri should not be an empty string');
     }
 
-    if (this.props.src) {
-      console.warn('The <Image> component requires a `source` property rather than `src`.');
-    }
+    if (source && source.uri) {
+      var {width, height} = source;
+      var style = flattenStyle([{width, height}, styles.base, this.props.style]);
+      var {onLoadStart, onLoad, onLoadEnd} = this.props;
 
-    if (this.context.isInAParentText) {
-      RawImage = RCTVirtualImage;
-      if (!width || !height) {
-        console.warn('You must specify a width and height for the image %s', uri);
+      var nativeProps = merge(this.props, {
+        style,
+        shouldNotifyLoadEvents: !!(onLoadStart || onLoad || onLoadEnd),
+        src: source.uri,
+        loadingIndicatorSrc: loadingIndicatorSource ? loadingIndicatorSource.uri : null,
+      });
+
+      if (nativeProps.children) {
+        // TODO(6033040): Consider implementing this as a separate native component
+        var imageProps = merge(nativeProps, {
+          style: styles.absoluteImage,
+          children: undefined,
+        });
+        return (
+          <View style={nativeProps.style}>
+            <RKImage {...imageProps}/>
+            {this.props.children}
+          </View>
+        );
+      } else {
+        if (this.context.isInAParentText) {
+          return <RCTTextInlineImage {...nativeProps}/>;
+        } else {
+          return <RKImage {...nativeProps}/>;
+        }
       }
     }
-
-    return (
-      <RawImage
-        {...this.props}
-        style={style}
-        resizeMode={resizeMode}
-        tintColor={tintColor}
-        source={source}
-      />
-    );
-  },
+    return null;
+  }
 });
 
 var styles = StyleSheet.create({
   base: {
     overflow: 'hidden',
   },
+  absoluteImage: {
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    position: 'absolute'
+  }
 });
 
-var RCTImageView = requireNativeComponent('RCTImageView', Image);
-var RCTNetworkImageView = NetworkImageViewManager ? requireNativeComponent('RCTNetworkImageView', Image) : RCTImageView;
-var RCTVirtualImage = requireNativeComponent('RCTVirtualImage', Image);
-
+var cfg = {
+  nativeOnly: {
+    src: true,
+    loadingIndicatorSrc: true,
+    defaultImageSrc: true,
+    imageTag: true,
+    progressHandlerRegistered: true,
+    shouldNotifyLoadEvents: true,
+  },
+};
+var RKImage = requireNativeComponent('RCTImageView', Image, cfg);
+var RCTTextInlineImage = requireNativeComponent('RCTTextInlineImage', Image, cfg);
 
 module.exports = Image;
-

--- a/ReactWindows/js/Vibration/VibrationIOS.windows.js
+++ b/ReactWindows/js/Vibration/VibrationIOS.windows.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * Stub of VibrationIOS for Windows.
+ *
+ * @providesModule VibrationIOS
+ */
+'use strict';
+
+var warning = require('warning');
+
+var VibrationIOS = {
+  vibrate: function() {
+    warning('VibrationIOS is not supported on this platform!');
+  }
+};
+
+module.exports = VibrationIOS;


### PR DESCRIPTION
Various views have no implementation for UWP, but we need a placeholder module in cases where we use conditional behavior based on the platform.