### PR TITLE
feat(UIExplorer): Adding unimplemented views for UWP

### DIFF
--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -360,7 +360,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Facebook.CSSLayout">
-      <HintPath>..\References\Facebook.CSSLayout.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)\..\References\Facebook.CSSLayout.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/ReactWindows/js/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js
+++ b/ReactWindows/js/Components/DrawerAndroid/DrawerLayoutAndroid.windows.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DrawerLayoutAndroid
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/ReactWindows/js/Components/StatusBar/StatusBarIOS.windows.js
+++ b/ReactWindows/js/Components/StatusBar/StatusBarIOS.windows.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule StatusBarIOS
+ * @flow
+ */
+'use strict';
+
+module.exports = null;

--- a/ReactWindows/js/Components/ToolbarAndroid/ToolbarAndroid.windows.js
+++ b/ReactWindows/js/Components/ToolbarAndroid/ToolbarAndroid.windows.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ToolbarAndroid
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/ReactWindows/js/Components/ViewPager/ViewPagerAndroid.windows.js
+++ b/ReactWindows/js/Components/ViewPager/ViewPagerAndroid.windows.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ViewPagerAndroid
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/ReactWindows/js/Vibration/VibrationIOS.windows.js
+++ b/ReactWindows/js/Vibration/VibrationIOS.windows.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * Stub of VibrationIOS for Windows.
+ *
+ * @providesModule VibrationIOS
+ */
+'use strict';
+
+var warning = require('warning');
+
+var VibrationIOS = {
+  vibrate: function() {
+    warning('VibrationIOS is not supported on this platform!');
+  }
+};
+
+module.exports = VibrationIOS;


### PR DESCRIPTION
Various views have no implementation for UWP, but we need a placeholder module in cases where we use conditional behavior based on the platform.