### PR TITLE
fix(LayoutShadowNode): Ensure that `onLayout` event fires

### DIFF
--- a/ReactWindows/ReactNative/UIManager/LayoutShadowNode.cs
+++ b/ReactWindows/ReactNative/UIManager/LayoutShadowNode.cs
@@ -207,5 +207,17 @@ namespace ReactNative.UIManager
                 ? EnumHelpers.Parse<CSSPositionType>(position)
                 : CSSPositionType.Relative;
         }
+
+        /// <summary>
+        /// Sets if the view should send an event on layout.
+        /// </summary>
+        /// <param name="shouldNotifyOnLayout">
+        /// The flag signaling if the view should sent an event on layout.
+        /// </param>
+        [ReactProperty("onLayout")]
+        public void SetShouldNotifyOnLayout(bool shouldNotifyOnLayout)
+        {
+            ShouldNotifyOnLayout = shouldNotifyOnLayout;
+        }
     }
 }


### PR DESCRIPTION
For the onLayout event to fire, the UIManager must set the `onLayout` prop to true. This changeset adds a ReactProperty handler for this to the LayoutShadowNode base class.

Fixes #297