### PR TITLE
fix(SplitViewWindows): Directly map SplitView child to parent

### DIFF
--- a/ReactWindows/ReactNative/UIManager/RootViewHelper.cs
+++ b/ReactWindows/ReactNative/UIManager/RootViewHelper.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml;
+﻿using System.Runtime.CompilerServices;
+using Windows.UI.Xaml;
 
 namespace ReactNative.UIManager
 {
@@ -7,6 +8,9 @@ namespace ReactNative.UIManager
     /// </summary>
     public static class RootViewHelper
     {
+        private static readonly ConditionalWeakTable<FrameworkElement, FrameworkElement> s_parent =
+            new ConditionalWeakTable<FrameworkElement, FrameworkElement>();
+
         /// <summary>
         /// Returns the root view of a givenview in a react application.
         /// </summary>
@@ -28,8 +32,42 @@ namespace ReactNative.UIManager
                     return rootView;
                 }
 
-                current = (FrameworkElement)current.Parent;
+                var mapped = default(FrameworkElement);
+                if (s_parent.TryGetValue(current, out mapped))
+                {
+                    current = mapped;
+                }
+                else
+                {
+                    current = (FrameworkElement)current.Parent;
+                }
             }
+        }
+
+        /// <summary>
+        /// Associate an element with its parent.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="parent">The parent.</param>
+        /// <remarks>
+        /// TODO: (#302) Remove this shim.
+        /// </remarks>
+        internal static void SetParent(this FrameworkElement element, FrameworkElement parent)
+        {
+            RemoveParent(element);
+            s_parent.Add(element, parent);
+        }
+
+        /// <summary>
+        /// Unassociate a parent element.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <remarks>
+        /// TODO: (#302) Remove this shim.
+        /// </remarks>
+        internal static void RemoveParent(this FrameworkElement element)
+        {
+            s_parent.Remove(element);
         }
     }
 }

--- a/ReactWindows/ReactNative/Views/Split/ReactSplitViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Split/ReactSplitViewManager.cs
@@ -83,7 +83,7 @@ namespace ReactNative.Views.Split
                 placement != SplitViewPanePlacement.Right)
             {
                 throw new ArgumentOutOfRangeException(
-                    nameof(panePosition), 
+                    nameof(panePosition),
                     $"Unknown pane position '{placement}'.");
             }
 
@@ -115,10 +115,12 @@ namespace ReactNative.Views.Split
             if (index == 0)
             {
                 parent.Content = child;
+                child.SetParent(parent);
             }
             else
             {
                 parent.Pane = child;
+                child.SetParent(parent);
             }
         }
 
@@ -178,12 +180,14 @@ namespace ReactNative.Views.Split
         {
             if (index == 0)
             {
-                EnsureContent(parent);
+                var content = EnsureContent(parent);
+                content.RemoveParent();
                 parent.Content = null;
             }
             else if (index == 0)
             {
-                EnsurePane(parent);
+                var pane = EnsurePane(parent);
+                pane.RemoveParent();
                 parent.Pane = null;
             }
             else


### PR DESCRIPTION
There seems to be a bug in XAML where the content in SplitView.Pane and SplitView.Content is not directly linked to its parent. This is a shim to ensure this link exists.

Fixes #290