### PR TITLE
feat(LauncherWindows): Adds LauncherWindows for Linking implementation

### DIFF
--- a/Examples/UIExplorer/UIExplorerList.windows.js
+++ b/Examples/UIExplorer/UIExplorerList.windows.js
@@ -53,6 +53,10 @@ const APIExamples = [
     module: require('./ClipboardExample'),
   },
   {
+    key: 'LinkingExample',
+    module: require('./LinkingExample'),
+  },
+  {
     key: 'LayoutExample',
     module: require('./LayoutExample'),
   },

--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -15,9 +15,14 @@ const Platform = require('Platform');
 const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 const {
   IntentAndroid,
-  LinkingManager: LinkingManagerIOS
+  LinkingManager: LinkingManagerIOS,
+  LauncherWindows
 } = require('NativeModules');
-const LinkingManager = Platform.OS === 'android' ? IntentAndroid : LinkingManagerIOS;
+const LinkingManager = Platform.OS === 'android' 
+  ? IntentAndroid 
+  : Platform.OS === 'ios'
+    ? LinkingManagerIOS
+    : LauncherWindows;
 const invariant = require('invariant');
 const Map = require('Map');
 
@@ -51,7 +56,7 @@ const DEVICE_NOTIF_EVENT = 'openURL';
  *
  * NOTE: For iOS, in case you also want to listen to incoming app links during your app's
  * execution you'll need to add the following lines to you `*AppDelegate.m`:
- *
+ * 
  * ```
  *#import "RCTLinkingManager.h" 
  *
@@ -116,8 +121,8 @@ class Linking {
    * @platform ios
    */
   static addEventListener(type: string, handler: Function) {
-    if (Platform.OS === 'android') {
-        console.warn('Linking.addEventListener is not supported on Android');
+    if (Platform.OS !== 'ios') {
+        console.warn('Linking.addEventListener is only supported on iOS');
     } else {
       invariant(
         type === 'url',
@@ -137,8 +142,8 @@ class Linking {
    * @platform ios
    */
   static removeEventListener(type: string, handler: Function ) {
-    if (Platform.OS === 'android') {
-        console.warn('Linking.removeEventListener is not supported on Android');
+    if (Platform.OS !== 'ios') {
+        console.warn('Linking.removeEventListener is only supported on iOS');
     } else {
       invariant(
         type === 'url',
@@ -189,6 +194,8 @@ class Linking {
    * it will give the link url, otherwise it will give `null`
    *
    * NOTE: To support deep linking on Android, refer http://developer.android.com/training/app-indexing/deep-linking.html#handling-intents
+   * 
+   * NOTE: This is not supported on Windows.
    */
   static getInitialURL(): Promise<?string> {
     if (Platform.OS === 'android') {

--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -56,7 +56,7 @@ const DEVICE_NOTIF_EVENT = 'openURL';
  *
  * NOTE: For iOS, in case you also want to listen to incoming app links during your app's
  * execution you'll need to add the following lines to you `*AppDelegate.m`:
- * 
+ *
  * ```
  *#import "RCTLinkingManager.h" 
  *

--- a/ReactWindows/ReactNative/Modules/Launch/LauncherModule.cs
+++ b/ReactWindows/ReactNative/Modules/Launch/LauncherModule.cs
@@ -1,0 +1,73 @@
+﻿using ReactNative.Bridge;
+using System;
+using Windows.System;
+
+namespace ReactNative.Modules.Launch
+{
+    class LauncherModule : NativeModuleBase
+    {
+        public override string Name
+        {
+            get
+            {
+                return "LauncherWindows";
+            }
+        }
+
+        [ReactMethod]
+        public async void openURL(string url, IPromise promise)
+        {
+            if (url == null)
+            {
+                promise.Reject(new ArgumentNullException(nameof(url)));
+                return;
+            }
+
+            var uri = default(Uri);
+            if (!Uri.TryCreate(url, UriKind.Absolute, out uri))
+            {
+                promise.Reject(new ArgumentException($"URL argument '{uri}' is not valid."));
+                return;
+            }
+
+            try
+            {
+                await Launcher.LaunchUriAsync(uri).AsTask().ConfigureAwait(false);
+                promise.Resolve(true);
+            }
+            catch (Exception ex)
+            {
+                promise.Reject(new InvalidOperationException(
+                    $"Could not open URL '{url}'.", ex));
+            }
+        }
+
+        [ReactMethod]
+        public async void canOpenURL(string url, IPromise promise)
+        {
+            if (url == null)
+            {
+                promise.Reject(new ArgumentNullException(nameof(url)));
+                return;
+            }
+
+            var uri = default(Uri);
+            if (!Uri.TryCreate(url, UriKind.Absolute, out uri))
+            {
+                promise.Reject(new ArgumentException($"URL argument '{uri}' is not valid."));
+                return;
+            }
+
+            try
+            {
+                var support = await Launcher.QueryUriSupportAsync(uri, LaunchQuerySupportType.Uri).AsTask().ConfigureAwait(false);
+                promise.Resolve(support == LaunchQuerySupportStatus.Available);
+            }
+            catch (Exception ex)
+            {
+                promise.Reject(new InvalidOperationException(
+                    $"Could not check if URL '{url}' can be opened.", ex));
+            }
+        }
+    }
+}

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -194,6 +194,7 @@
     <Compile Include="Modules\Core\JavaScriptException.cs" />
     <Compile Include="Modules\Core\JSTimersExecution.cs" />
     <Compile Include="Modules\Core\SourceCodeModule.cs" />
+    <Compile Include="Modules\Launch\LauncherModule.cs" />
     <Compile Include="Modules\NetInfo\DefaultNetworkInformation.cs" />
     <Compile Include="Modules\NetInfo\IConnectionProfile.cs" />
     <Compile Include="Modules\NetInfo\INetworkInformation.cs" />

--- a/ReactWindows/ReactNative/Shell/MainReactPackage.cs
+++ b/ReactWindows/ReactNative/Shell/MainReactPackage.cs
@@ -2,9 +2,10 @@
 using ReactNative.Modules.AppState;
 using ReactNative.Modules.Clipboard;
 using ReactNative.Modules.Core;
-using ReactNative.Modules.StatusBar;
+using ReactNative.Modules.Launch;
 using ReactNative.Modules.NetInfo;
 using ReactNative.Modules.Network;
+using ReactNative.Modules.StatusBar;
 using ReactNative.Modules.Storage;
 using ReactNative.Modules.Toast;
 using ReactNative.Modules.WebSocket;
@@ -42,6 +43,7 @@ namespace ReactNative.Shell
                 //new CameraRollManager(reactContext),
                 new ClipboardModule(),
                 //new DialogModule(reactContext),
+                new LauncherModule(),
                 //new LocationModule(reactContext),
                 new NetworkingModule(reactContext),
                 new NetInfoModule(reactContext),

--- a/ReactWindows/js/Components/Touchable/TouchableNativeFeedback.windows.js
+++ b/ReactWindows/js/Components/Touchable/TouchableNativeFeedback.windows.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule TouchableNativeFeedback
+ */
+
+'use strict';
+
+var React = require('React');
+var StyleSheet = require('StyleSheet');
+var Text = require('Text');
+var View = require('View');
+
+var DummyTouchableNativeFeedback = React.createClass({
+  render: function() {
+    return (
+      <View style={[styles.container, this.props.style]}>
+        <Text style={styles.info}>TouchableNativeFeedback is not supported on this platform!</Text>
+      </View>
+    );
+  },
+});
+
+var styles = StyleSheet.create({
+  container: {
+    height: 100,
+    width: 300,
+    backgroundColor: '#ffbcbc',
+    borderWidth: 1,
+    borderColor: 'red',
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 10,
+  },
+  info: {
+    color: '#333333',
+    margin: 20,
+  }
+});
+
+module.exports = DummyTouchableNativeFeedback;


### PR DESCRIPTION
React Native has a module, Linking, that checks for launchability of URIs and launches them accordingly. This changeset adds LauncherWindows, which is analagous to LinkingManagerIOS and IntentAndroid.

We do not yet support the getInitialURL API, but have an open ticket to introduce this feature (#301).

Fixes #299