### PR TITLE
fix(Text): Use virtual nodes for text spans in Windows

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -246,6 +246,13 @@ if (Platform.OS === 'android') {
     }),
     uiViewClassName: 'RCTVirtualText',
   });
+} else if (Platform.OS === 'windows') {
+  RCTVirtualText = createReactNativeComponentClass({
+    validAttributes: merge(ReactNativeViewAttributes.UIView, {
+      isHighlighted: true,
+    }),
+    uiViewClassName: 'RCTVirtualText',
+  });   
 }
 
 module.exports = Text;

--- a/ReactWindows/ReactNative/UIManager/ReactShadowNode.cs
+++ b/ReactWindows/ReactNative/UIManager/ReactShadowNode.cs
@@ -550,10 +550,7 @@ namespace ReactNative.UIManager
         /// <summary>
         /// Marks that the node is dirty.
         /// </summary>
-        /// <remarks>
-        /// TODO: (#289) Reseal when issue is resolved.
-        /// </remarks>
-        protected override void dirty()
+        protected sealed override void dirty()
         {
             if (!IsVirtual)
             {

--- a/ReactWindows/ReactNative/Views/Text/ReactRawTextManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactRawTextManager.cs
@@ -9,8 +9,6 @@ namespace ReactNative.Views.Text
     /// </summary>
     public class ReactRawTextManager : ReactTextViewManager
     {
-        private const string ReactClass = "RCTRawText";
-
         /// <summary>
         /// The name of the view manager.
         /// </summary>
@@ -18,7 +16,7 @@ namespace ReactNative.Views.Text
         {
             get
             {
-                return ReactClass;
+                return "RCTRawText";
             }
         }
 

--- a/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactTextShadowNode.cs
@@ -210,20 +210,6 @@ namespace ReactNative.Views.Text
         }
 
         /// <summary>
-        /// Marks that the node is dirty.
-        /// </summary> 
-        /// <remarks>
-        /// TODO: (#289) Remove when resolved.
-        /// </remarks>
-        protected sealed override void dirty()
-        {
-            if (!HasNewLayout)
-            {
-                base.dirty();
-            }
-        }
-
-        /// <summary>
         /// Formats an inline instance with shadow properties..
         /// </summary>
         /// <param name="textNode">The text shadow node.</param>
@@ -299,12 +285,12 @@ namespace ReactNative.Views.Text
 
         class ReactTextShadowNodeInlineVisitor : CSSNodeVisitor<Inline>
         {
-            private static ReactTextShadowNodeInlineVisitor s_instance = new ReactTextShadowNodeInlineVisitor();
+            private static readonly ReactTextShadowNodeInlineVisitor s_instance = new ReactTextShadowNodeInlineVisitor();
 
             public static Inline Apply(CSSNode node)
             {
                 return s_instance.Visit(node);
-            } 
+            }
 
             protected sealed override Inline Make(CSSNode node, IList<Inline> children)
             {

--- a/ReactWindows/ReactNative/Views/Text/ReactVirtualTextViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Text/ReactVirtualTextViewManager.cs
@@ -5,8 +5,6 @@
     /// </summary>
     public class ReactVirtualTextViewManager : ReactRawTextManager
     {
-        private const string ReactClass = "RCTVirtualText";
-
         /// <summary>
         /// The view manager name.
         /// </summary>
@@ -14,7 +12,7 @@
         {
             get
             {
-                return ReactClass;
+                return "RCTVirtualText";
             }
         }
     }


### PR DESCRIPTION
Windows was not using virtual nodes for internal spans, causing problems with when things were marked as dirty. Adds platform specific handling to Text.js and deletes hacks to avoid the crashing bug for dirty layouts.

Fixes #289