### PR TITLE
feat(ScrollView): Adds begin and end drag events for ScrollView

### DIFF
--- a/ReactWindows/ReactNative/Views/Scroll/ScrollEventType.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ScrollEventType.cs
@@ -6,6 +6,16 @@
     public enum ScrollEventType
     {
         /// <summary>
+        /// The begin drag event.
+        /// </summary>
+        BeginDrag,
+
+        /// <summary>
+        /// The end drag event.
+        /// </summary>
+        EndDrag,
+
+        /// <summary>
         /// The scroll event.
         /// </summary>
         Scroll,

--- a/ReactWindows/ReactNative/Views/Scroll/ScrollEventTypeExtensions.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ScrollEventTypeExtensions.cs
@@ -8,6 +8,10 @@ namespace ReactNative.Views.Scroll
         {
             switch (type)
             {
+                case ScrollEventType.BeginDrag:
+                    return "topScrollBeginDrag";
+                case ScrollEventType.EndDrag:
+                    return "topScrollEndDrag";
                 case ScrollEventType.Scroll:
                     return "topScroll";
                 default:


### PR DESCRIPTION
It's useful to know when the user is manipulating the scroll view and no longer manipulating. Using events exposed on the XAML view to add `onScrollBeginDrag` and `onScrollEndDrag` events for ScrollView.

Fixes #332