### PR TITLE
hack(ScrollView): The most embarassing hack of my life

### DIFF
--- a/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
@@ -322,6 +322,8 @@ namespace ReactNative.Views.Scroll
                 scrollViewer.HorizontalOffset,
                 scrollViewer.VerticalOffset,
                 scrollViewer.ZoomFactor);
+
+            // TODO: (#327) Remove all this fake touch nonsense
             EmitFakeTouch(scrollViewer);
         }
 
@@ -467,19 +469,22 @@ namespace ReactNative.Views.Scroll
 
         class FakeTouchEvent : Event
         {
-            private static readonly JArray s_dummyTouches = new JArray
-            {
-                JToken.FromObject(new ReactPointer()),
-            };
-
             private static readonly JArray s_dummyIndices = new JArray { 0 };
 
             private readonly TouchEventType _touchEventType;
+            private readonly JArray _touches;
 
             public FakeTouchEvent(int viewTag, TouchEventType touchEventType)
                 : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
             {
                 _touchEventType = touchEventType;
+                _touches = new JArray
+                {
+                    JToken.FromObject(new FakePointer
+                    {
+                        Target = viewTag,
+                    }),
+                };
             }
 
             public override string EventName
@@ -492,22 +497,16 @@ namespace ReactNative.Views.Scroll
 
             public override void Dispatch(RCTEventEmitter eventEmitter)
             {
-                eventEmitter.receiveTouches(EventName, s_dummyTouches, s_dummyIndices);
+                eventEmitter.receiveTouches(EventName, _touches, s_dummyIndices);
             }
 
-            class ReactPointer
+            class FakePointer
             {
                 [JsonProperty(PropertyName = "target")]
                 public int Target { get; set; }
 
-                [JsonIgnore]
-                public uint PointerId { get; set; }
-
                 [JsonProperty(PropertyName = "identifier")]
                 public uint Identifier { get; set; }
-
-                [JsonIgnore]
-                public FrameworkElement ReactView { get; set; }
 
                 [JsonProperty(PropertyName = "timestamp")]
                 public ulong Timestamp { get; set; }

--- a/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
+++ b/ReactWindows/ReactNative/Views/Scroll/ReactScrollViewManager.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using ReactNative.UIManager;
 using ReactNative.UIManager.Events;
 using System;
@@ -321,6 +322,7 @@ namespace ReactNative.Views.Scroll
                 scrollViewer.HorizontalOffset,
                 scrollViewer.VerticalOffset,
                 scrollViewer.ZoomFactor);
+            EmitFakeTouch(scrollViewer);
         }
 
         private void OnDirectManipulationStarted(object sender, object e)
@@ -403,6 +405,17 @@ namespace ReactNative.Views.Scroll
                             { "zoomScale", zoomFactor },
                         }));
         }
+        
+        private void EmitFakeTouch(ScrollViewer scrollViewer)
+        {
+            var reactTag = scrollViewer.GetTag();
+            var eventDispatcher = scrollViewer.GetReactContext()
+                .GetNativeModule<UIManagerModule>()
+                .EventDispatcher;
+
+            eventDispatcher.DispatchEvent(new FakeTouchEvent(reactTag, TouchEventType.Start));
+            eventDispatcher.DispatchEvent(new FakeTouchEvent(reactTag, TouchEventType.End));
+        }
 
         private static FrameworkElement EnsureChild(ScrollViewer view)
         {
@@ -449,6 +462,67 @@ namespace ReactNative.Views.Scroll
             public override void Dispatch(RCTEventEmitter eventEmitter)
             {
                 eventEmitter.receiveEvent(ViewTag, EventName, _data);
+            }
+        }
+
+        class FakeTouchEvent : Event
+        {
+            private static readonly JArray s_dummyTouches = new JArray
+            {
+                JToken.FromObject(new ReactPointer()),
+            };
+
+            private static readonly JArray s_dummyIndices = new JArray { 0 };
+
+            private readonly TouchEventType _touchEventType;
+
+            public FakeTouchEvent(int viewTag, TouchEventType touchEventType)
+                : base(viewTag, TimeSpan.FromTicks(Environment.TickCount))
+            {
+                _touchEventType = touchEventType;
+            }
+
+            public override string EventName
+            {
+                get
+                {
+                    return _touchEventType.GetJavaScriptEventName();
+                }
+            }
+
+            public override void Dispatch(RCTEventEmitter eventEmitter)
+            {
+                eventEmitter.receiveTouches(EventName, s_dummyTouches, s_dummyIndices);
+            }
+
+            class ReactPointer
+            {
+                [JsonProperty(PropertyName = "target")]
+                public int Target { get; set; }
+
+                [JsonIgnore]
+                public uint PointerId { get; set; }
+
+                [JsonProperty(PropertyName = "identifier")]
+                public uint Identifier { get; set; }
+
+                [JsonIgnore]
+                public FrameworkElement ReactView { get; set; }
+
+                [JsonProperty(PropertyName = "timestamp")]
+                public ulong Timestamp { get; set; }
+
+                [JsonProperty(PropertyName = "locationX")]
+                public float LocationX { get; set; }
+
+                [JsonProperty(PropertyName = "locationY")]
+                public float LocationY { get; set; }
+
+                [JsonProperty(PropertyName = "pageX")]
+                public float PageX { get; set; }
+
+                [JsonProperty(PropertyName = "pageY")]
+                public float PageY { get; set; }
             }
         }
     }


### PR DESCRIPTION
This is really not a good idea guys. In fact, it's horrible. I'll hardly be able to sleep after this. This is horrible.

To give a rough overview of what's going on here, in XAML, after the ScrollViewer captures the pointer for scrolling, it immediately cancels the pointer that started the scroll in the first place, giving the following sequence of events: topTouchStart -> topTouchCancel -> topScrollBeginDrag -> topScroll -> topScrollEndDrag.

The expectation for React is that the entire sequence will be punctuated with an "endish" (look it up, they use the word in the React code base) touch event so the active responder (in this case, the scroll responder) can be released.

So, to overcome the fact that we don't have an "endish" punctuation, we make one happen, by simulating a touch. I know. It's gross.