### PR TITLE
fix(Assets): All assets must be loaded from URI

### DIFF
--- a/ReactWindows/.gitignore
+++ b/ReactWindows/.gitignore
@@ -1,5 +1,6 @@
 *AppPackages*
 *BundleArtifacts*
+*ReactAssets*
 
 #OS junk files
 [Tt]humbs.db

--- a/ReactWindows/Playground/AppReactPage.cs
+++ b/ReactWindows/Playground/AppReactPage.cs
@@ -23,6 +23,16 @@ namespace Playground
             }
         }
 
+#if BUNDLE
+        public override string JavaScriptBundleFile
+        {
+            get
+            {
+                return "ms-appx:///ReactAssets/index.windows.bundle";
+            }
+        }
+#endif
+
         public override List<IReactPackage> Packages
         {
             get

--- a/ReactWindows/Playground/Playground.csproj
+++ b/ReactWindows/Playground/Playground.csproj
@@ -89,7 +89,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseBundle|x86'">
     <OutputPath>bin\x86\ReleaseBundle\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;BUNDLE</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <NoStdLib>true</NoStdLib>
@@ -102,7 +102,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseBundle|ARM'">
     <OutputPath>bin\ARM\ReleaseBundle\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;BUNDLE</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <NoStdLib>true</NoStdLib>
@@ -115,7 +115,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseBundle|x64'">
     <OutputPath>bin\x64\ReleaseBundle\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;BUNDLE</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <NoStdLib>true</NoStdLib>
@@ -129,7 +129,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugBundle|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\DebugBundle\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;BUNDLE</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <NoStdLib>true</NoStdLib>
     <DebugType>full</DebugType>
@@ -142,7 +142,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugBundle|ARM'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\ARM\DebugBundle\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;BUNDLE</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <NoStdLib>true</NoStdLib>
     <DebugType>full</DebugType>
@@ -155,7 +155,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugBundle|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\DebugBundle\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP;CODE_ANALYSIS;BUNDLE</DefineConstants>
     <NoWarn>;2008</NoWarn>
     <NoStdLib>true</NoStdLib>
     <DebugType>full</DebugType>

--- a/ReactWindows/ReactNative/Bridge/JavaScriptBundleLoader.cs
+++ b/ReactWindows/ReactNative/Bridge/JavaScriptBundleLoader.cs
@@ -86,10 +86,7 @@ namespace ReactNative.Bridge
             {
                 try
                 {
-                    var storageFile = SourceUrl.StartsWith("file:///")
-                        ? await StorageFile.GetFileFromPathAsync(SourceUrl)
-                        : await StorageFile.GetFileFromApplicationUriAsync(new Uri(SourceUrl));
-
+                    var storageFile = await StorageFile.GetFileFromApplicationUriAsync(new Uri(SourceUrl));
                     using (var stream = await storageFile.OpenStreamForReadAsync())
                     using (var reader = new StreamReader(stream))
                     {


### PR DESCRIPTION
Currently, the Image API we're using does not support loading images from a file path. You can use something like "ms-appdata:///local", but not "c:\tmp\". This change ensures the bundle path, which is the base path for the local assets, is a URI.

Fixes #338