### PR TITLE
chore(DotNetNative): Enable .NET Native Compilation for apps

### DIFF
--- a/ReactWindows/ReactNative/Chakra/JavaScriptContext.cs
+++ b/ReactWindows/ReactNative/Chakra/JavaScriptContext.cs
@@ -88,22 +88,6 @@
         }
 
         /// <summary>
-        ///     Gets a value indicating whether the heap of the current context is being enumerated.
-        /// </summary>
-        /// <remarks>
-        ///     Requires an active script context.
-        /// </remarks>
-        public static bool IsEnumeratingHeap
-        {
-            get
-            {
-                bool isEnumerating;
-                Native.ThrowIfError(Native.JsIsEnumeratingHeap(out isEnumerating));
-                return isEnumerating;
-            }
-        }
-
-        /// <summary>
         ///     Gets the runtime that the context belongs to.
         /// </summary>
         public JavaScriptRuntime Runtime
@@ -360,59 +344,6 @@
         public static void StartDebugging()
         {
             Native.ThrowIfError(Native.JsStartDebugging());
-        }
-
-        /// <summary>
-        ///     Starts profiling in the current context.
-        /// </summary>
-        /// <remarks>
-        ///     Requires an active script context.
-        /// </remarks>
-        /// <param name="callback">The profiling callback to use.</param>
-        /// <param name="eventMask">The profiling events to callback with.</param>
-        /// <param name="context">A context to pass to the profiling callback.</param>
-        public static void StartProfiling(Native.IActiveScriptProfilerCallback callback, Native.ProfilerEventMask eventMask, int context)
-        {
-            Native.ThrowIfError(Native.JsStartProfiling(callback, eventMask, context));
-        }
-
-        /// <summary>
-        ///     Stops profiling in the current context.
-        /// </summary>
-        /// <remarks>
-        ///     <para>
-        ///     Will not return an error if profiling has not started.
-        ///     </para>
-        ///     <para>
-        ///     Requires an active script context.
-        ///     </para>
-        /// </remarks>
-        /// <param name="reason">
-        ///     The reason for stopping profiling to pass to the profiler callback.
-        /// </param>
-        public static void StopProfiling(int reason)
-        {
-            Native.ThrowIfError(Native.JsStopProfiling(reason));
-        }
-
-        /// <summary>
-        ///     Enumerates the heap of the current context.
-        /// </summary>
-        /// <remarks>
-        ///     <para>
-        ///     While the heap is being enumerated, the current context cannot be removed, and all calls to
-        ///     modify the state of the context will fail until the heap enumerator is released.
-        ///     </para>
-        ///     <para>
-        ///     Requires an active script context.
-        ///     </para>
-        /// </remarks>
-        /// <returns>A heap enumerator.</returns>
-        public static Native.IActiveScriptProfilerHeapEnum EnumerateHeap()
-        {
-            Native.IActiveScriptProfilerHeapEnum enumerator;
-            Native.ThrowIfError(Native.JsEnumerateHeap(out enumerator));
-            return enumerator;
         }
 
         /// <summary>

--- a/ReactWindows/ReactNative/Chakra/Native.cs
+++ b/ReactWindows/ReactNative/Chakra/Native.cs
@@ -620,18 +620,6 @@
         [DllImport("chakra.dll", ExactSpelling = true)]
         internal static extern JavaScriptErrorCode JsIsRuntimeExecutionDisabled(JavaScriptRuntime runtime, out bool isDisabled);
 
-        [DllImport("chakra.dll", ExactSpelling = true)]
-        internal static extern JavaScriptErrorCode JsStartProfiling(IActiveScriptProfilerCallback callback, ProfilerEventMask eventMask, int context);
-
-        [DllImport("chakra.dll", ExactSpelling = true)]
-        internal static extern JavaScriptErrorCode JsStopProfiling(int reason);
-
-        [DllImport("chakra.dll", ExactSpelling = true)]
-        internal static extern JavaScriptErrorCode JsEnumerateHeap(out IActiveScriptProfilerHeapEnum enumerator);
-
-        [DllImport("chakra.dll", ExactSpelling = true)]
-        internal static extern JavaScriptErrorCode JsIsEnumeratingHeap(out bool isEnumeratingHeap);
-
         [DllImport("chakra.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern JavaScriptErrorCode JsProjectWinRTNamespace(string namespaceName);
 

--- a/ReactWindows/ReactNative/ReactNative.csproj
+++ b/ReactWindows/ReactNative/ReactNative.csproj
@@ -53,7 +53,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;NO_REFLECTION</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <DebugType>pdbonly</DebugType>
@@ -77,7 +77,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
     <PlatformTarget>ARM</PlatformTarget>
     <OutputPath>bin\ARM\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;NO_REFLECTION</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <DebugType>pdbonly</DebugType>
@@ -101,7 +101,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP;NO_REFLECTION</DefineConstants>
     <Optimize>true</Optimize>
     <NoWarn>;2008</NoWarn>
     <DebugType>pdbonly</DebugType>
@@ -216,6 +216,7 @@
     <Compile Include="ReactPage.cs" />
     <Compile Include="ReactRootView.cs" />
     <Compile Include="Reflection\EnumHelpers.cs" />
+    <Compile Include="Reflection\EnumHelpers.Static.cs" />
     <Compile Include="Touch\IOnInterceptTouchEventListener.cs" />
     <Compile Include="Touch\TouchHandler.cs" />
     <Compile Include="UIManager\BorderExtensions.cs" />

--- a/ReactWindows/ReactNative/Reflection/EnumHelpers.Static.cs
+++ b/ReactWindows/ReactNative/Reflection/EnumHelpers.Static.cs
@@ -1,0 +1,232 @@
+﻿#if NO_REFLECTION
+using Facebook.CSSLayout;
+using ReactNative.UIManager.LayoutAnimation;
+using System;
+using Windows.UI.Text;
+using Windows.UI.Xaml;
+
+namespace ReactNative.Reflection
+{
+    static partial class EnumHelpers
+    {
+        public static T ParseStatic<T>(string value)
+        {
+            if (typeof(T) == typeof(CSSFlexDirection))
+            {
+                return (T)ParseFlexDirection(value);
+            }
+            else if (typeof(T) == typeof(CSSWrap))
+            {
+                return (T)ParseWrap(value);
+            }
+            else if (typeof(T) == typeof(CSSAlign))
+            {
+                return (T)ParseAlign(value);
+            }
+            else if (typeof(T) == typeof(CSSJustify))
+            {
+                return (T)ParseJustify(value);
+            }
+            else if (typeof(T) == typeof(CSSPositionType))
+            {
+                return (T)ParsePositionType(value);
+            }
+            else if (typeof(T) == typeof(TextAlignment))
+            {
+                return (T)ParseTextAlignment(value);
+            }
+            else if (typeof(T) == typeof(VerticalAlignment))
+            {
+                return (T)ParseVerticalAlignment(value);
+            }
+            else if (typeof(T) == typeof(FontStyle))
+            {
+                return (T)ParseFontStyle(value);
+            }
+            else if (typeof(T) == typeof(AnimatedPropertyType))
+            {
+                return (T)ParseAnimatedPropertyType(value);
+            }
+            else if (typeof(T) == typeof(InterpolationType))
+            {
+                return (T)ParseInterpolationType(value);
+            }
+            else
+            {
+                throw new NotImplementedException(
+                    $"Enum parsing is not implemented for type '{typeof(T)}'.");
+            }
+        }
+
+        private static object ParseFlexDirection(string value)
+        {
+            switch (value)
+            {
+                case "column":
+                    return CSSFlexDirection.Column;
+                case "columnReverse":
+                    return CSSFlexDirection.ColumnReverse;
+                case "row":
+                    return CSSFlexDirection.Row;
+                case "rowReverse":
+                    return CSSFlexDirection.RowReverse;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(CSSFlexDirection)}'.");
+            }
+        }
+
+        private static object ParseWrap(string value)
+        {
+            switch (value)
+            {
+                case "nowrap":
+                    return CSSWrap.NoWrap;
+                case "wrap":
+                    return CSSWrap.Wrap;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(CSSWrap)}'.");
+            }
+        }
+
+        private static object ParseAlign(string value)
+        {
+            switch (value)
+            {
+                case "auto":
+                    return CSSAlign.Auto;
+                case "flex-start":
+                    return CSSAlign.FlexStart;
+                case "center":
+                    return CSSAlign.Center;
+                case "flex-end":
+                    return CSSAlign.FlexEnd;
+                case "stretch":
+                    return CSSAlign.Stretch;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(CSSAlign)}'.");
+            }
+        }
+
+        private static object ParseJustify(string value)
+        {
+            switch (value)
+            {
+                case "flex-start":
+                    return CSSJustify.FlexStart;
+                case "center":
+                    return CSSJustify.Center;
+                case "flex-end":
+                    return CSSJustify.FlexEnd;
+                case "space-between":
+                    return CSSJustify.SpaceBetween;
+                case "space-around":
+                    return CSSJustify.SpaceAround;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(CSSJustify)}'.");
+            }
+        }
+
+        private static object ParsePositionType(string value)
+        {
+            switch (value)
+            {
+                case "relative":
+                    return CSSPositionType.Relative;
+                case "absolute":
+                    return CSSPositionType.Absolute;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(CSSPositionType)}'.");
+            }
+        }
+
+        private static object ParseTextAlignment(string value)
+        {
+            switch (value)
+            {
+                case "center":
+                    return TextAlignment.Center;
+                case "left":
+                    return TextAlignment.Left;
+                case "right":
+                    return TextAlignment.Right;
+                case "justify":
+                    return TextAlignment.Justify;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(TextAlignment)}'.");
+            }
+        }
+
+        private static object ParseVerticalAlignment(string value)
+        {
+            switch (value)
+            {
+                case "top":
+                    return VerticalAlignment.Top;
+                case "center":
+                    return VerticalAlignment.Center;
+                case "bottom":
+                    return VerticalAlignment.Bottom;
+                case "stretch":
+                    return VerticalAlignment.Stretch;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(VerticalAlignment)}'.");
+            }
+        }
+
+        private static object ParseFontStyle(string value)
+        {
+            switch (value)
+            {
+                case "normal":
+                    return FontStyle.Normal;
+                case "italic":
+                    return FontStyle.Italic;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(FontStyle)}'.");
+            }
+        }
+
+        private static object ParseAnimatedPropertyType(string value)
+        {
+            switch (value)
+            {
+                case "opacity":
+                    return AnimatedPropertyType.Opacity;
+                case "scaleXY":
+                    return AnimatedPropertyType.ScaleXY;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(AnimatedPropertyType)}'.");
+            }
+        }
+
+        private static object ParseInterpolationType(string value)
+        {
+            switch (value)
+            {
+                case "linear":
+                    return InterpolationType.Linear;
+                case "easeIn":
+                    return InterpolationType.EaseIn;
+                case "easeOut":
+                    return InterpolationType.EaseOut;
+                case "easeInEaseOut":
+                    return InterpolationType.EaseInEaseOut;
+                case "spring":
+                    return InterpolationType.Spring;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value), $"Unexpected value '{value}' for enum type '{typeof(InterpolationType)}'.");
+            }
+        }
+    }
+}
+#endif

--- a/ReactWindows/ReactNative/Reflection/EnumHelpers.cs
+++ b/ReactWindows/ReactNative/Reflection/EnumHelpers.cs
@@ -6,13 +6,16 @@ using System.Linq;
 
 namespace ReactNative.Reflection
 {
-    static class EnumHelpers
+    static partial class EnumHelpers
     {
         private static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, object>> s_enumCache =
             new ConcurrentDictionary<Type, IReadOnlyDictionary<string, object>>();
 
         public static T Parse<T>(string value)
         {
+#if NO_REFLECTION
+            return ParseStatic<T>(value);
+#else
             var lookup = s_enumCache.GetOrAdd(
                 typeof(T),
                 type => Enum.GetValues(type)
@@ -30,6 +33,7 @@ namespace ReactNative.Reflection
             }
 
             return (T)result;
+#endif
         }
 
         public static T? ParseNullable<T>(string value)


### PR DESCRIPTION
To submit apps to the Universal Windows store, they must be compiled using .NET Native. Reflection is crippled in .NET Native, so some things like the EnumHelpers implementation that relies on reflection will not work. Some of the Chakra APIs are also not supported in store apps.

Fixes #215